### PR TITLE
Matchmaking/Battle contract integration

### DIFF
--- a/Assets/Scenes/Sandbox.unity
+++ b/Assets/Scenes/Sandbox.unity
@@ -151,6 +151,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2047726732}
   m_RootOrder: 0
@@ -285,6 +286,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 356143085}
   m_Father: {fileID: 233001426}
@@ -455,6 +457,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 91.40488, y: 91.40488, z: 91.40488}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 786477989}
   - {fileID: 932336753}
@@ -533,6 +536,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1506054964}
   m_Father: {fileID: 1078973366}
@@ -607,6 +611,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 9.881474, y: 9.881474, z: 9.881474}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1299962426}
   m_RootOrder: 3
@@ -642,6 +647,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 9.881474, y: 9.881474, z: 9.881474}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 541548003}
   m_RootOrder: 1
@@ -679,6 +685,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1654223204}
   m_Father: {fileID: 902561126}
@@ -755,6 +762,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 902561126}
   m_RootOrder: 0
@@ -889,6 +897,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 850524114}
   m_RootOrder: 0
@@ -1023,6 +1032,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1825251808}
   m_RootOrder: 2
@@ -1098,6 +1108,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 546803091}
   m_RootOrder: 6
@@ -1173,6 +1184,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 440561645}
   m_RootOrder: 0
@@ -1286,6 +1298,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1709664802}
   m_RootOrder: 0
@@ -1361,6 +1374,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 383476241}
   m_RootOrder: 0
@@ -1398,6 +1412,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 557078692}
   - {fileID: 1280148725}
@@ -1475,6 +1490,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 440561645}
   m_RootOrder: 2
@@ -1609,6 +1625,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 293441790}
   m_RootOrder: 0
@@ -1743,6 +1760,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 233001426}
   m_RootOrder: 1
@@ -1816,6 +1834,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1654777832}
   - {fileID: 227203860}
@@ -1867,6 +1886,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1742971593}
   m_RootOrder: 4
@@ -1942,6 +1962,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 949527256}
   m_Father: {fileID: 1742971593}
@@ -2018,6 +2039,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 221706569}
   - {fileID: 581407846}
@@ -2095,6 +2117,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 233001426}
   m_RootOrder: 4
@@ -2205,6 +2228,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 91.40488, y: 91.40488, z: 91.40488}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1181253929}
   - {fileID: 347218566}
@@ -2283,6 +2307,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 343958139}
   m_RootOrder: 1
@@ -2417,6 +2442,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 29002505}
   m_RootOrder: 0
@@ -2492,6 +2518,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1575310337}
   m_RootOrder: 0
@@ -2661,6 +2688,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 91.40488, y: 91.40488, z: 91.40488}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 161871875}
   - {fileID: 571052828}
@@ -2737,6 +2765,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 9.881474, y: 9.881474, z: 9.881474}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 541548003}
   m_RootOrder: 3
@@ -2774,6 +2803,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1825251808}
   m_RootOrder: 1
@@ -2908,6 +2938,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1078973366}
   m_RootOrder: 0
@@ -3042,6 +3073,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1514970249}
   m_RootOrder: 2
@@ -3117,6 +3149,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 724251692}
   m_RootOrder: 0
@@ -3249,6 +3282,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 9.881474, y: 9.881474, z: 9.881474}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 541548003}
   m_RootOrder: 0
@@ -3285,6 +3319,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 134005057}
   - {fileID: 1742971593}
@@ -3397,6 +3432,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1514970249}
   m_RootOrder: 1
@@ -3566,6 +3602,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 91.40488, y: 91.40488, z: 91.40488}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 2130638785}
   - {fileID: 1844991079}
@@ -3643,6 +3680,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1311145140}
   - {fileID: 1778919607}
@@ -3704,6 +3742,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 795337085}
   m_RootOrder: 0
@@ -3817,6 +3856,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1514970249}
   m_RootOrder: 0
@@ -3854,6 +3894,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 495210509}
   m_RootOrder: 5
@@ -3929,6 +3970,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1356961485}
   m_RootOrder: 2
@@ -4005,6 +4047,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 427676802}
   - {fileID: 79337248}
@@ -4111,6 +4154,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 495210509}
   - {fileID: 1594373888}
@@ -4193,6 +4237,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 184228537}
   m_RootOrder: 0
@@ -4327,6 +4372,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 383476241}
   m_RootOrder: 1
@@ -4499,6 +4545,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 924435005}
   m_RootOrder: 0
@@ -4536,6 +4583,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 710395204}
   m_Father: {fileID: 293441790}
@@ -4612,6 +4660,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1742971593}
   m_RootOrder: 2
@@ -4685,6 +4734,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 9.881474, y: 9.881474, z: 9.881474}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1299962426}
   m_RootOrder: 2
@@ -4722,6 +4772,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 581407846}
   m_RootOrder: 0
@@ -4856,6 +4907,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2110859544}
   m_RootOrder: 0
@@ -4991,6 +5043,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 0.64757, y: 0.64757, z: 0.64757}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 417418620}
   m_Father: {fileID: 546803091}
@@ -5041,7 +5094,7 @@ CanvasRenderer:
   m_CullTransparentMesh: 1
 --- !u!95 &724251695
 Animator:
-  serializedVersion: 3
+  serializedVersion: 4
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
@@ -5054,6 +5107,7 @@ Animator:
   m_UpdateMode: 0
   m_ApplyRootMotion: 0
   m_LinearVelocityBlending: 0
+  m_StabilizeFeet: 0
   m_WarningMessage: 
   m_HasTransformHierarchy: 1
   m_AllowConstantClipSamplingOptimization: 1
@@ -5149,6 +5203,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 0, y: 0, z: 0}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 856851553}
   - {fileID: 546803091}
@@ -5261,6 +5316,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1825251808}
   m_RootOrder: 0
@@ -5298,6 +5354,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 343958139}
   m_RootOrder: 2
@@ -5373,6 +5430,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 829266210}
   - {fileID: 1022606271}
@@ -5488,6 +5546,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 33741716}
   m_RootOrder: 0
@@ -5524,6 +5583,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 508222018}
   - {fileID: 233001426}
@@ -5636,6 +5696,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1198905631}
   m_Father: {fileID: 1286285634}
@@ -5712,6 +5773,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 782004295}
   m_RootOrder: 0
@@ -5846,6 +5908,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 119017003}
   - {fileID: 1337858755}
@@ -5925,6 +5988,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4f231c4fb786f3946a6b90b886c48677, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  m_SendPointerHoverToParent: 1
   m_HorizontalAxis: Horizontal
   m_VerticalAxis: Vertical
   m_SubmitButton: Submit
@@ -5957,6 +6021,7 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -960, y: -540, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 731252688}
   m_RootOrder: 0
@@ -5989,6 +6054,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 546803091}
   m_RootOrder: 5
@@ -6099,6 +6165,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 91.40488, y: 91.40488, z: 91.40488}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1199090944}
   - {fileID: 910611899}
@@ -6177,6 +6244,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: -1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1507566102}
   m_RootOrder: 0
@@ -6311,6 +6379,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 108590886}
   - {fileID: 86889150}
@@ -6388,6 +6457,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 885881230}
   m_RootOrder: 1
@@ -6557,6 +6627,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 91.40488, y: 91.40488, z: 91.40488}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 576879005}
   - {fileID: 958118700}
@@ -6635,6 +6706,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 33741716}
   m_RootOrder: 1
@@ -6769,6 +6841,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: -1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1413718267}
   m_RootOrder: 0
@@ -6903,6 +6976,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 1, z: 0, w: 0}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 279892702}
   m_RootOrder: 0
@@ -6978,6 +7052,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 472418680}
   m_RootOrder: 2
@@ -7053,6 +7128,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 885881230}
   m_RootOrder: 2
@@ -7128,6 +7204,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 924435005}
   m_RootOrder: 1
@@ -7313,6 +7390,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 1, z: -62}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 0
@@ -7345,6 +7423,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2071001091}
   m_RootOrder: 0
@@ -7479,6 +7558,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1526171618}
   m_Father: {fileID: 1741266181}
@@ -7555,6 +7635,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1103514284}
   m_Father: {fileID: 782004295}
@@ -7631,6 +7712,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1337858755}
   m_RootOrder: 0
@@ -7763,6 +7845,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 9.881474, y: 9.881474, z: 9.881474}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1299962426}
   m_RootOrder: 1
@@ -7800,6 +7883,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1741266181}
   m_RootOrder: 1
@@ -7934,6 +8018,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 33741716}
   m_RootOrder: 2
@@ -8009,6 +8094,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 401977995}
   - {fileID: 53572237}
@@ -8086,6 +8172,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1280148725}
   m_RootOrder: 0
@@ -8220,6 +8307,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1022606271}
   m_RootOrder: 0
@@ -8354,6 +8442,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1558685788}
   m_RootOrder: 0
@@ -8429,6 +8518,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 1, z: 0, w: 0}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1654777832}
   m_RootOrder: 0
@@ -8504,6 +8594,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 233001426}
   m_RootOrder: 13
@@ -8638,6 +8729,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 924435005}
   m_RootOrder: 2
@@ -8751,6 +8843,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 343958139}
   m_RootOrder: 0
@@ -8788,6 +8881,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 807140056}
   m_RootOrder: 0
@@ -8960,6 +9054,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 885881230}
   m_RootOrder: 0
@@ -8997,6 +9092,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 2049588391}
   - {fileID: 2047726732}
@@ -9074,6 +9170,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1709664802}
   m_RootOrder: 2
@@ -9149,6 +9246,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1095795666}
   m_Father: {fileID: 184228537}
@@ -9225,6 +9323,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1750358326}
   m_RootOrder: 0
@@ -9359,6 +9458,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1898684482}
   - {fileID: 807140056}
@@ -9437,6 +9537,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1903341206}
   - {fileID: 1058871707}
@@ -9543,6 +9644,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1887938112}
   - {fileID: 1835798704}
@@ -9621,6 +9723,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 495210509}
   m_RootOrder: 0
@@ -9708,6 +9811,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1030918004}
   m_Father: {fileID: 850524114}
@@ -9819,6 +9923,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 91.40488, y: 91.40488, z: 91.40488}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1557224944}
   - {fileID: 2133533661}
@@ -9897,6 +10002,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 795337085}
   m_RootOrder: 2
@@ -10031,6 +10137,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 0.38172, y: 0.38172, z: 0.38172}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1709664802}
   m_RootOrder: 1
@@ -10165,6 +10272,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: -1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 946853127}
   - {fileID: 1815815362}
@@ -10242,6 +10350,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 233001426}
   m_RootOrder: 12
@@ -10376,6 +10485,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 53572237}
   m_RootOrder: 0
@@ -10510,6 +10620,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: -1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 892625172}
   - {fileID: 1668413263}
@@ -10622,6 +10733,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 91.40488, y: 91.40488, z: 91.40488}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 522547979}
   - {fileID: 442765018}
@@ -10700,6 +10812,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1020526883}
   m_RootOrder: 0
@@ -10834,6 +10947,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1742971593}
   m_RootOrder: 12
@@ -11006,6 +11120,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1356961485}
   m_RootOrder: 0
@@ -11043,6 +11158,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1108995524}
   m_Father: {fileID: 1742971593}
@@ -11178,6 +11294,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 379784614}
   m_Father: {fileID: 2071001091}
@@ -11254,6 +11371,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1594373888}
   m_RootOrder: 0
@@ -11328,6 +11446,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1579594729}
   - {fileID: 1847898828}
@@ -11341,7 +11460,7 @@ RectTransform:
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!95 &1594373889
 Animator:
-  serializedVersion: 3
+  serializedVersion: 4
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
@@ -11354,6 +11473,7 @@ Animator:
   m_UpdateMode: 0
   m_ApplyRootMotion: 0
   m_LinearVelocityBlending: 0
+  m_StabilizeFeet: 0
   m_WarningMessage: 
   m_HasTransformHierarchy: 1
   m_AllowConstantClipSamplingOptimization: 1
@@ -11386,6 +11506,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1742971593}
   m_RootOrder: 1
@@ -11461,6 +11582,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 86889150}
   m_RootOrder: 0
@@ -11595,6 +11717,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1114433898}
   m_Father: {fileID: 233001426}
@@ -11671,6 +11794,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 383476241}
   m_RootOrder: 2
@@ -11746,6 +11870,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: -1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1507566102}
   m_RootOrder: 1
@@ -11915,6 +12040,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 91.40488, y: 91.40488, z: 91.40488}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 149797546}
   - {fileID: 1405574374}
@@ -11993,6 +12119,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1020526883}
   - {fileID: 1070300088}
@@ -12068,6 +12195,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 279892702}
   - {fileID: 1609409808}
@@ -12119,6 +12247,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1286222159}
   - {fileID: 440561645}
@@ -12198,6 +12327,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 495210509}
   m_RootOrder: 1
@@ -12286,6 +12416,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 0.62343, y: 0.62343, z: 0.62343}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1813735434}
   m_Father: {fileID: 546803091}
@@ -12336,7 +12467,7 @@ CanvasRenderer:
   m_CullTransparentMesh: 1
 --- !u!95 &1806537178
 Animator:
-  serializedVersion: 3
+  serializedVersion: 4
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
@@ -12349,6 +12480,7 @@ Animator:
   m_UpdateMode: 0
   m_ApplyRootMotion: 0
   m_LinearVelocityBlending: 0
+  m_StabilizeFeet: 0
   m_WarningMessage: 
   m_HasTransformHierarchy: 1
   m_AllowConstantClipSamplingOptimization: 1
@@ -12381,6 +12513,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1806537175}
   m_RootOrder: 0
@@ -12515,6 +12648,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: -1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1413718267}
   m_RootOrder: 1
@@ -12684,6 +12818,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 91.40488, y: 91.40488, z: 91.40488}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 743036393}
   - {fileID: 393517558}
@@ -12762,6 +12897,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1303299123}
   m_RootOrder: 1
@@ -12894,6 +13030,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 9.881474, y: 9.881474, z: 9.881474}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1299962426}
   m_RootOrder: 4
@@ -12931,6 +13068,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 472418680}
   m_RootOrder: 1
@@ -13065,6 +13203,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1594373888}
   m_RootOrder: 1
@@ -13370,6 +13509,7 @@ MonoBehaviour:
   playAutomatically: 1
   player1Controller: {fileID: 440561646}
   player2Controller: {fileID: 795337086}
+  CardsScriptableObjsData: {fileID: 11400000, guid: d1fea7aba5f19cc45991de3bac22c468, type: 2}
 --- !u!4 &1869662263
 Transform:
   m_ObjectHideFlags: 0
@@ -13380,6 +13520,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 2
@@ -13412,6 +13553,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1956677086}
   m_Father: {fileID: 1303299123}
@@ -13486,6 +13628,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 9.881474, y: 9.881474, z: 9.881474}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 541548003}
   m_RootOrder: 2
@@ -13523,6 +13666,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1286285634}
   m_RootOrder: 0
@@ -13655,6 +13799,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 9.881474, y: 9.881474, z: 9.881474}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1299962426}
   m_RootOrder: 0
@@ -13692,6 +13837,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 440561645}
   m_RootOrder: 3
@@ -13826,6 +13972,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 2107914722}
   m_Father: {fileID: 2110859544}
@@ -13902,6 +14049,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1887938112}
   m_RootOrder: 0
@@ -14037,6 +14185,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 546803091}
   m_RootOrder: 2
@@ -14138,6 +14287,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 795337085}
   m_RootOrder: 3
@@ -14272,6 +14422,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 233001426}
   m_RootOrder: 2
@@ -14347,6 +14498,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 17534859}
   m_Father: {fileID: 1233192303}
@@ -14423,6 +14575,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1233192303}
   m_RootOrder: 0
@@ -14557,6 +14710,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 980232296}
   - {fileID: 1575310337}
@@ -14632,6 +14786,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 9.881474, y: 9.881474, z: 9.881474}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 541548003}
   m_RootOrder: 4
@@ -14669,6 +14824,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1942171322}
   m_RootOrder: 0
@@ -14803,6 +14959,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 711290005}
   - {fileID: 1942171322}
@@ -14918,6 +15075,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 472418680}
   m_RootOrder: 0
@@ -14955,6 +15113,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1356961485}
   m_RootOrder: 1
@@ -15089,6 +15248,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1742971593}
   m_RootOrder: 13

--- a/Assets/Scenes/StartScreen.unity
+++ b/Assets/Scenes/StartScreen.unity
@@ -6764,11 +6764,11 @@ MonoBehaviour:
       chainCurrencySymbol: MATIC
       chainCurrencyDecimals: 18
       rpcUrl: https://rpc.ankr.com/polygon_mumbai
-      pepemonBattleAddress: 0x04bB7b7d7fb2E8e37095b65cB828Ced8a7b5A01D
+      pepemonBattleAddress: 0x16018De06b116b044f257Fe58d915e5da048CE14
       pepemonFactoryAddress: 0x5aC1254f6c8cD976e796c951D7fE92eEF0eB70BE
       pepemonCardDeckAddress: 0xa784b4fcFe0cF627aD2Be650d5467597FCFBFf67
       pepemonMatchmakerAddresses:
-      - 0x231d3f09394938B073ec650dAcF2EA850BF95196
+      - 0x0941517e79a5898B46318B2C66634aa5928fC70f
     - chainId: 31337
       chainName: hardhat
       chainCurrencyName: ETH

--- a/Assets/Scenes/StartScreen.unity
+++ b/Assets/Scenes/StartScreen.unity
@@ -1031,6 +1031,86 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 404256356}
   m_CullTransparentMesh: 1
+--- !u!1 &411141033
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 411141034}
+  - component: {fileID: 411141036}
+  - component: {fileID: 411141035}
+  m_Layer: 5
+  m_Name: Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &411141034
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 411141033}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1406872819}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &411141035
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 411141033}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 12800000, guid: 75495cc934d4e90449c805f660317dc9, type: 3}
+    m_FontSize: 76
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 2
+    m_MaxSize: 130
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Mint cards
+--- !u!222 &411141036
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 411141033}
+  m_CullTransparentMesh: 1
 --- !u!1 &453832911
 GameObject:
   m_ObjectHideFlags: 0
@@ -1481,7 +1561,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1157378619}
-  m_RootOrder: 3
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -2506,7 +2586,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: -0.000061035156}
-  m_SizeDelta: {x: 0, y: -843.7887}
+  m_SizeDelta: {x: 0, y: -919.20703}
   m_Pivot: {x: 0, y: 1}
 --- !u!114 &686953499
 MonoBehaviour:
@@ -2786,12 +2866,12 @@ RectTransform:
   - {fileID: 1684403124}
   - {fileID: 845498422}
   m_Father: {fileID: 1157378619}
-  m_RootOrder: 2
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 960, y: -661.89435}
-  m_SizeDelta: {x: 1920, y: 923.7887}
+  m_AnchoredPosition: {x: 960, y: -699.6035}
+  m_SizeDelta: {x: 1920, y: 999.20703}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &725896988
 MonoBehaviour:
@@ -5390,6 +5470,7 @@ RectTransform:
   m_Children:
   - {fileID: 727523884}
   - {fileID: 1986635109}
+  - {fileID: 1406872819}
   - {fileID: 725896987}
   - {fileID: 486681337}
   m_Father: {fileID: 1399361489}
@@ -5414,6 +5495,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _deckDisplay: {fileID: 725896986}
   _saveDeckButton: {fileID: 1986635108}
+  _mintCardsButton: {fileID: 1406872818}
+  _previousScreenButton: {fileID: 727523883}
   _textLoading: {fileID: 486681336}
 --- !u!114 &1157378621
 MonoBehaviour:
@@ -7633,6 +7716,161 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 0}
+--- !u!1 &1406872818
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1406872819}
+  - component: {fileID: 1406872823}
+  - component: {fileID: 1406872822}
+  - component: {fileID: 1406872821}
+  - component: {fileID: 1406872820}
+  m_Layer: 5
+  m_Name: Button_MintCards
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1406872819
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1406872818}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.99997026, y: 0.99997026, z: 0.99997026}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 411141034}
+  m_Father: {fileID: 1157378619}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 1}
+  m_AnchorMax: {x: 0.5, y: 1}
+  m_AnchoredPosition: {x: 200, y: -20}
+  m_SizeDelta: {x: 420, y: 160}
+  m_Pivot: {x: 1, y: 1}
+--- !u!114 &1406872820
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1406872818}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 306cc8c2b49d7114eaa3623786fc2126, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreLayout: 1
+  m_MinWidth: -1
+  m_MinHeight: -1
+  m_PreferredWidth: -1
+  m_PreferredHeight: -1
+  m_FlexibleWidth: -1
+  m_FlexibleHeight: -1
+  m_LayoutPriority: 1
+--- !u!114 &1406872821
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1406872818}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 1406872822}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 0}
+        m_TargetAssemblyTypeName: MainMenuController, Assembly-CSharp
+        m_MethodName: 
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: 
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!114 &1406872822
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1406872818}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 0.5411765, b: 0.25882354, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: a9248a31ac5209f46b2b09a077df6222, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1406872823
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1406872818}
+  m_CullTransparentMesh: 1
 --- !u!1 &1414184211
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/StartScreen.unity
+++ b/Assets/Scenes/StartScreen.unity
@@ -886,94 +886,6 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!1 &393188702
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 393188703}
-  - component: {fileID: 393188705}
-  - component: {fileID: 393188704}
-  m_Layer: 5
-  m_Name: DevDebugTimer
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &393188703
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 393188702}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 894610814}
-  m_RootOrder: 2
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 960, y: -698.64813}
-  m_SizeDelta: {x: 1920, y: 100}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &393188704
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 393188702}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: ce2a32dea3dde934cae879120b275536, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  delaySeconds: 4
-  triggerOnEnable: 1
-  triggerOnStart: 0
-  action:
-    m_PersistentCalls:
-      m_Calls:
-      - m_Target: {fileID: 1399361485}
-        m_TargetAssemblyTypeName: MainMenuController, Assembly-CSharp
-        m_MethodName: ProceedToNextScene
-        m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
---- !u!114 &393188705
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 393188702}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 306cc8c2b49d7114eaa3623786fc2126, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_IgnoreLayout: 1
-  m_MinWidth: -1
-  m_MinHeight: -1
-  m_PreferredWidth: -1
-  m_PreferredHeight: -1
-  m_FlexibleWidth: -1
-  m_FlexibleHeight: -1
-  m_LayoutPriority: 1
 --- !u!1 &404256356
 GameObject:
   m_ObjectHideFlags: 0
@@ -1979,13 +1891,13 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 894610814}
+  m_Father: {fileID: 784467681}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 960, y: -471.63763}
-  m_SizeDelta: {x: 1920, y: 256}
+  m_AnchoredPosition: {x: 960.00006, y: -128}
+  m_SizeDelta: {x: 1920.0001, y: 256}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &614026748
 MonoBehaviour:
@@ -2146,7 +2058,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 320, y: -730.29626}
+  m_AnchoredPosition: {x: 320, y: -661.89435}
   m_SizeDelta: {x: 640, y: 640}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &630232705
@@ -2377,7 +2289,7 @@ MonoBehaviour:
   m_HandleRect: {fileID: 1582037413}
   m_Direction: 2
   m_Value: 1
-  m_Size: 0.93580115
+  m_Size: 1
   m_NumberOfSteps: 0
   m_OnValueChanged:
     m_PersistentCalls:
@@ -2594,7 +2506,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: -0.000061035156}
-  m_SizeDelta: {x: 0, y: -1080.3644}
+  m_SizeDelta: {x: 0, y: -843.7887}
   m_Pivot: {x: 0, y: 1}
 --- !u!114 &686953499
 MonoBehaviour:
@@ -2878,8 +2790,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 960, y: -780.1822}
-  m_SizeDelta: {x: 1920, y: 1160.3644}
+  m_AnchoredPosition: {x: 960, y: -661.89435}
+  m_SizeDelta: {x: 1920, y: 923.7887}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &725896988
 MonoBehaviour:
@@ -3159,7 +3071,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 960, y: -362.638}
+  m_AnchoredPosition: {x: 960, y: -336.89435}
   m_SizeDelta: {x: 1000, y: 140}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &781226658
@@ -3256,6 +3168,88 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 781226656}
   m_CullTransparentMesh: 1
+--- !u!1 &784467680
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 784467681}
+  - component: {fileID: 784467683}
+  - component: {fileID: 784467682}
+  m_Layer: 5
+  m_Name: Container
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &784467681
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 784467680}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 614026746}
+  - {fileID: 1255983250}
+  m_Father: {fileID: 894610814}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 960, y: -568.10315}
+  m_SizeDelta: {x: 1920.0001, y: 355.0105}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!111 &784467682
+Animation:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 784467680}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Animation: {fileID: 7400000, guid: a27a9252f1180744583b6050f2fa5f22, type: 2}
+  m_Animations:
+  - {fileID: 7400000, guid: a27a9252f1180744583b6050f2fa5f22, type: 2}
+  m_WrapMode: 0
+  m_PlayAutomatically: 1
+  m_AnimatePhysics: 0
+  m_CullingType: 0
+--- !u!114 &784467683
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 784467680}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 59f8146938fff824cb5fd77236b75775, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Padding:
+    m_Left: 0
+    m_Right: 0
+    m_Top: 0
+    m_Bottom: 0
+  m_ChildAlignment: 0
+  m_Spacing: 0
+  m_ChildForceExpandWidth: 1
+  m_ChildForceExpandHeight: 1
+  m_ChildControlWidth: 0
+  m_ChildControlHeight: 0
+  m_ChildScaleWidth: 0
+  m_ChildScaleHeight: 0
+  m_ReverseArrangement: 0
 --- !u!1 &822351928
 GameObject:
   m_ObjectHideFlags: 0
@@ -3395,8 +3389,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 1440, y: -580.1822}
-  m_SizeDelta: {x: 960, y: 1160.3644}
+  m_AnchoredPosition: {x: 1440, y: -461.89435}
+  m_SizeDelta: {x: 960, y: 923.7887}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &845498423
 MonoBehaviour:
@@ -3477,7 +3471,6 @@ GameObject:
   - component: {fileID: 894610814}
   - component: {fileID: 894610813}
   - component: {fileID: 894610812}
-  - component: {fileID: 894610815}
   m_Layer: 5
   m_Name: Screen_7_WaitForOpponent
   m_TagString: Untagged
@@ -3531,9 +3524,8 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 614026746}
-  - {fileID: 1255983250}
-  - {fileID: 393188703}
+  - {fileID: 784467681}
+  - {fileID: 1353372987}
   m_Father: {fileID: 1399361489}
   m_RootOrder: 10
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -3542,22 +3534,6 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!111 &894610815
-Animation:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 894610811}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Animation: {fileID: 7400000, guid: a27a9252f1180744583b6050f2fa5f22, type: 2}
-  m_Animations:
-  - {fileID: 7400000, guid: a27a9252f1180744583b6050f2fa5f22, type: 2}
-  m_WrapMode: 0
-  m_PlayAutomatically: 1
-  m_AnimatePhysics: 0
-  m_CullingType: 0
 --- !u!1 &909697254
 GameObject:
   m_ObjectHideFlags: 0
@@ -3686,7 +3662,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 960, y: -812.63806}
+  m_AnchoredPosition: {x: 960, y: -786.89435}
   m_SizeDelta: {x: 1000, y: 140}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &969319545
@@ -3867,7 +3843,7 @@ MonoBehaviour:
   m_HandleRect: {fileID: 1759157553}
   m_Direction: 2
   m_Value: 1
-  m_Size: 0.93580115
+  m_Size: 1
   m_NumberOfSteps: 0
   m_OnValueChanged:
     m_PersistentCalls:
@@ -4542,6 +4518,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _searchForOpponentButton: {fileID: 1421260176}
+  _exitButton: {fileID: 1353372986}
   _deckList: {fileID: 453832911}
 --- !u!1 &1021123132
 GameObject:
@@ -6259,7 +6236,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
   m_AnchoredPosition: {x: 940, y: -411.481}
-  m_SizeDelta: {x: 1880, y: 400}
+  m_SizeDelta: {x: 1880, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1248269245
 MonoBehaviour:
@@ -6389,13 +6366,13 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 894610814}
+  m_Father: {fileID: 784467681}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 960, y: -649.14294}
-  m_SizeDelta: {x: 1920, y: 99.01045}
+  m_AnchoredPosition: {x: 960.00006, y: -305.50525}
+  m_SizeDelta: {x: 1920.0001, y: 99.01045}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1255983251
 MonoBehaviour:
@@ -6603,7 +6580,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 1600, y: -730.29626}
+  m_AnchoredPosition: {x: 1600, y: -661.89435}
   m_SizeDelta: {x: 640, y: 640}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1319189953
@@ -6787,7 +6764,7 @@ MonoBehaviour:
       chainCurrencySymbol: MATIC
       chainCurrencyDecimals: 18
       rpcUrl: https://rpc.ankr.com/polygon_mumbai
-      pepemonBattleAddress: 0xf8f6DF81b66Cb0d1Bd629E35a740Fa01DC285727
+      pepemonBattleAddress: 0x04bB7b7d7fb2E8e37095b65cB828Ced8a7b5A01D
       pepemonFactoryAddress: 0x5aC1254f6c8cD976e796c951D7fE92eEF0eB70BE
       pepemonCardDeckAddress: 0xa784b4fcFe0cF627aD2Be650d5467597FCFBFf67
       pepemonMatchmakerAddresses:
@@ -6798,11 +6775,11 @@ MonoBehaviour:
       chainCurrencySymbol: ETH
       chainCurrencyDecimals: 18
       rpcUrl: http://localhost:8545
-      pepemonBattleAddress: 0xc229bb2DbCF1F8283816cc44b626b1E8Bd153d7b
+      pepemonBattleAddress: 0x3DF3b26eE45f131960383323b2f9988E73967300
       pepemonFactoryAddress: 0x5aC1254f6c8cD976e796c951D7fE92eEF0eB70BE
-      pepemonCardDeckAddress: 0x3cDC8E90D6f0a1a99eb0F645b6cb9a83e7a2b4c2
+      pepemonCardDeckAddress: 0x1b5A60703C73E261633FeD34B6316B9485C51AA2
       pepemonMatchmakerAddresses:
-      - 0x3d23927F6abC9d2025b15a063607474CB0E4AcA2
+      - 0x014D30E03f242fcB8B5cF9B1e50efCfF8B7c5213
     defaultChainId: 80001
     debugRpcUrl: https://rpc.ankr.com/polygon_mumbai
     debugPrivateKey: 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
@@ -7042,6 +7019,161 @@ MonoBehaviour:
   m_FlexibleWidth: -1
   m_FlexibleHeight: -1
   m_LayoutPriority: 2
+--- !u!1 &1353372986
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1353372987}
+  - component: {fileID: 1353372991}
+  - component: {fileID: 1353372990}
+  - component: {fileID: 1353372989}
+  - component: {fileID: 1353372988}
+  m_Layer: 5
+  m_Name: Button_Exit
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1353372987
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1353372986}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1.0000287, y: 1.0000287, z: 1.0000287}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1605375520}
+  m_Father: {fileID: 894610814}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0}
+  m_AnchorMax: {x: 0.5, y: 0}
+  m_AnchoredPosition: {x: 0, y: 20}
+  m_SizeDelta: {x: 400, y: 160}
+  m_Pivot: {x: 0.5, y: 0}
+--- !u!114 &1353372988
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1353372986}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 306cc8c2b49d7114eaa3623786fc2126, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreLayout: 1
+  m_MinWidth: -1
+  m_MinHeight: -1
+  m_PreferredWidth: -1
+  m_PreferredHeight: -1
+  m_FlexibleWidth: -1
+  m_FlexibleHeight: -1
+  m_LayoutPriority: 1
+--- !u!114 &1353372989
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1353372986}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.6509804}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 0
+  m_TargetGraphic: {fileID: 1353372990}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 1399361485}
+        m_TargetAssemblyTypeName: MainMenuController, Assembly-CSharp
+        m_MethodName: EnterMatch
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 7
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!114 &1353372990
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1353372986}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 0.5411765, b: 0.25882354, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 0.15
+--- !u!222 &1353372991
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1353372986}
+  m_CullTransparentMesh: 1
 --- !u!1 &1379687546
 GameObject:
   m_ObjectHideFlags: 0
@@ -7079,7 +7211,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 960, y: -512.638}
+  m_AnchoredPosition: {x: 960, y: -486.89435}
   m_SizeDelta: {x: 1000, y: 140}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1379687548
@@ -7217,7 +7349,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 960, y: -730.29626}
+  m_AnchoredPosition: {x: 960, y: -661.89435}
   m_SizeDelta: {x: 640, y: 640}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1379819351
@@ -8254,7 +8386,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 960, y: -662.638}
+  m_AnchoredPosition: {x: 960, y: -636.89435}
   m_SizeDelta: {x: 1000, y: 140}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1515001109
@@ -8780,7 +8912,7 @@ RectTransform:
   m_Father: {fileID: 1648680001}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0.06419885}
+  m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 20, y: 20}
@@ -9328,6 +9460,86 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1600901462}
   m_CullTransparentMesh: 1
+--- !u!1 &1605375519
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1605375520}
+  - component: {fileID: 1605375522}
+  - component: {fileID: 1605375521}
+  m_Layer: 5
+  m_Name: Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1605375520
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1605375519}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1353372987}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1605375521
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1605375519}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 12800000, guid: 75495cc934d4e90449c805f660317dc9, type: 3}
+    m_FontSize: 76
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 0
+    m_MaxSize: 120
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Exit
+--- !u!222 &1605375522
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1605375519}
+  m_CullTransparentMesh: 1
 --- !u!1 &1607395228
 GameObject:
   m_ObjectHideFlags: 0
@@ -9536,8 +9748,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 480, y: -580.1822}
-  m_SizeDelta: {x: 960, y: 1160.3644}
+  m_AnchoredPosition: {x: 480, y: -461.89435}
+  m_SizeDelta: {x: 960, y: 923.7887}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1684403125
 MonoBehaviour:
@@ -9875,7 +10087,7 @@ RectTransform:
   m_Father: {fileID: 1533277805}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0.06419885}
+  m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 20, y: 20}
@@ -9953,8 +10165,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 960, y: -590.5199}
-  m_SizeDelta: {x: 1920, y: 1181.0398}
+  m_AnchoredPosition: {x: 960, y: -561.89435}
+  m_SizeDelta: {x: 1920, y: 1123.7887}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1768398029
 MonoBehaviour:
@@ -10126,7 +10338,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: -0.000061035156}
-  m_SizeDelta: {x: 0, y: -1080.3644}
+  m_SizeDelta: {x: 0, y: -843.7887}
   m_Pivot: {x: 0, y: 1}
 --- !u!114 &1879408879
 MonoBehaviour:

--- a/Assets/Scenes/StartScreen.unity
+++ b/Assets/Scenes/StartScreen.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.37311918, g: 0.3807398, b: 0.35872716, a: 1}
+  m_IndirectSpecularColor: {r: 0.37311953, g: 0.38074014, b: 0.3587274, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -1254,7 +1254,10 @@ MonoBehaviour:
   _deckList: {fileID: 453832911}
   _loadingMessage: {fileID: 1926825175}
   _deckEditMode: 0
-  onItemSelected:
+  onEditDeck:
+    m_PersistentCalls:
+      m_Calls: []
+  onSelectDeck:
     m_PersistentCalls:
       m_Calls: []
 --- !u!114 &453832918
@@ -2216,9 +2219,9 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 1399361485}
-        m_TargetAssemblyTypeName: MainMenuController, Assembly-CSharp
-        m_MethodName: SelectLeague
+      - m_Target: {fileID: 1016897154}
+        m_TargetAssemblyTypeName: BattlePrepController, Assembly-CSharp
+        m_MethodName: SetLeague
         m_Mode: 3
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -4458,6 +4461,7 @@ GameObject:
   - component: {fileID: 1016897151}
   - component: {fileID: 1016897153}
   - component: {fileID: 1016897152}
+  - component: {fileID: 1016897154}
   m_Layer: 5
   m_Name: Screen_4_DeckSelection
   m_TagString: Untagged
@@ -4525,6 +4529,20 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1016897150}
   m_CullTransparentMesh: 1
+--- !u!114 &1016897154
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1016897150}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b1b06452cb3f9f34abff20f82c8066c0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _searchForOpponentButton: {fileID: 1421260176}
+  _deckList: {fileID: 453832911}
 --- !u!1 &1021123132
 GameObject:
   m_ObjectHideFlags: 0
@@ -6321,7 +6339,10 @@ MonoBehaviour:
   _deckList: {fileID: 1248269243}
   _loadingMessage: {fileID: 1341068232}
   _deckEditMode: 1
-  onItemSelected:
+  onEditDeck:
+    m_PersistentCalls:
+      m_Calls: []
+  onSelectDeck:
     m_PersistentCalls:
       m_Calls: []
 --- !u!114 &1248269250
@@ -6655,9 +6676,9 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 1399361485}
-        m_TargetAssemblyTypeName: MainMenuController, Assembly-CSharp
-        m_MethodName: SelectLeague
+      - m_Target: {fileID: 1016897154}
+        m_TargetAssemblyTypeName: BattlePrepController, Assembly-CSharp
+        m_MethodName: SetLeague
         m_Mode: 3
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -6769,15 +6790,19 @@ MonoBehaviour:
       pepemonBattleAddress: 0xf8f6DF81b66Cb0d1Bd629E35a740Fa01DC285727
       pepemonFactoryAddress: 0x5aC1254f6c8cD976e796c951D7fE92eEF0eB70BE
       pepemonCardDeckAddress: 0xa784b4fcFe0cF627aD2Be650d5467597FCFBFf67
+      pepemonMatchmakerAddresses:
+      - 0x231d3f09394938B073ec650dAcF2EA850BF95196
     - chainId: 31337
       chainName: hardhat
       chainCurrencyName: ETH
       chainCurrencySymbol: ETH
       chainCurrencyDecimals: 18
       rpcUrl: http://localhost:8545
-      pepemonBattleAddress: 0xf8f6DF81b66Cb0d1Bd629E35a740Fa01DC285727
+      pepemonBattleAddress: 0xc229bb2DbCF1F8283816cc44b626b1E8Bd153d7b
       pepemonFactoryAddress: 0x5aC1254f6c8cD976e796c951D7fE92eEF0eB70BE
-      pepemonCardDeckAddress: 0x586cF8aE2C7Bd0fF6456Ee9a32FCd1364898Fe8f
+      pepemonCardDeckAddress: 0x3cDC8E90D6f0a1a99eb0F645b6cb9a83e7a2b4c2
+      pepemonMatchmakerAddresses:
+      - 0x3d23927F6abC9d2025b15a063607474CB0E4AcA2
     defaultChainId: 80001
     debugRpcUrl: https://rpc.ankr.com/polygon_mumbai
     debugPrivateKey: 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
@@ -7265,9 +7290,9 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 1399361485}
-        m_TargetAssemblyTypeName: MainMenuController, Assembly-CSharp
-        m_MethodName: SelectLeague
+      - m_Target: {fileID: 1016897154}
+        m_TargetAssemblyTypeName: BattlePrepController, Assembly-CSharp
+        m_MethodName: SetLeague
         m_Mode: 3
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -7800,8 +7825,8 @@ MonoBehaviour:
       m_Calls:
       - m_Target: {fileID: 1399361485}
         m_TargetAssemblyTypeName: MainMenuController, Assembly-CSharp
-        m_MethodName: ShowScreen
-        m_Mode: 3
+        m_MethodName: EnterMatch
+        m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine

--- a/Assets/ScriptableObjects/Cards/Block.asset
+++ b/Assets/ScriptableObjects/Cards/Block.asset
@@ -18,23 +18,23 @@ MonoBehaviour:
   DisplayName: Block
   CardDescription: Pepemon adds +3 to its Defense Power until end of turn
   Rarity: 0
-  Type: 1
+  Type: 2
   CardEffectSprite: {fileID: 21300000, guid: 615e4be81ceb6494b90a43580122d31e, type: 3}
   AttackPower: 0
   DefensePower: 3
   effectOne:
-    basePower: 1
+    basePower: 3
     triggeredPower: 0
-    effectTo: 1
-    effectFor: 1
+    effectTo: 2
+    effectFor: 0
     reqCode: 0
   effectMany:
-    power: 2
-    numTurns: 2
-    effectTo: 3
+    power: 0
+    numTurns: 0
+    effectTo: 0
     effectFor: 0
-    reqCode: 10
+    reqCode: 0
   Unstackable: 0
-  Unresettable: 1
+  Unresettable: 0
   UnstackableAmount: 0
   UnresettableAmount: 0

--- a/Assets/ScriptableObjects/Cards/Block.asset
+++ b/Assets/ScriptableObjects/Cards/Block.asset
@@ -18,11 +18,23 @@ MonoBehaviour:
   DisplayName: Block
   CardDescription: Pepemon adds +3 to its Defense Power until end of turn
   Rarity: 0
-  Type: 2
+  Type: 1
   CardEffectSprite: {fileID: 21300000, guid: 615e4be81ceb6494b90a43580122d31e, type: 3}
   AttackPower: 0
   DefensePower: 3
+  effectOne:
+    basePower: 1
+    triggeredPower: 0
+    effectTo: 1
+    effectFor: 1
+    reqCode: 0
+  effectMany:
+    power: 2
+    numTurns: 2
+    effectTo: 3
+    effectFor: 0
+    reqCode: 10
   Unstackable: 0
-  Unresettable: 0
+  Unresettable: 1
   UnstackableAmount: 0
   UnresettableAmount: 0

--- a/Assets/ScriptableObjects/Cards/BlockWithARock.asset
+++ b/Assets/ScriptableObjects/Cards/BlockWithARock.asset
@@ -18,11 +18,23 @@ MonoBehaviour:
   DisplayName: Block With A Rock
   CardDescription: Pepemon adds +5 to its Defense Power until end of turn.
   Rarity: 0
-  Type: 2
+  Type: 1
   CardEffectSprite: {fileID: 21300000, guid: 482b8614fa77f984a8c8c988a4aa2712, type: 3}
   AttackPower: 0
   DefensePower: 5
-  Unstackable: 0
-  Unresettable: 0
+  effectOne:
+    basePower: 1
+    triggeredPower: 3
+    effectTo: 4
+    effectFor: 0
+    reqCode: 10
+  effectMany:
+    power: 4
+    numTurns: 2
+    effectTo: 0
+    effectFor: 1
+    reqCode: 2
+  Unstackable: 1
+  Unresettable: 1
   UnstackableAmount: 0
   UnresettableAmount: 0

--- a/Assets/ScriptableObjects/Cards/BlockWithARock.asset
+++ b/Assets/ScriptableObjects/Cards/BlockWithARock.asset
@@ -18,23 +18,23 @@ MonoBehaviour:
   DisplayName: Block With A Rock
   CardDescription: Pepemon adds +5 to its Defense Power until end of turn.
   Rarity: 0
-  Type: 1
+  Type: 2
   CardEffectSprite: {fileID: 21300000, guid: 482b8614fa77f984a8c8c988a4aa2712, type: 3}
   AttackPower: 0
   DefensePower: 5
   effectOne:
-    basePower: 1
-    triggeredPower: 3
-    effectTo: 4
+    basePower: 5
+    triggeredPower: 0
+    effectTo: 2
     effectFor: 0
-    reqCode: 10
+    reqCode: 0
   effectMany:
-    power: 4
-    numTurns: 2
+    power: 0
+    numTurns: 0
     effectTo: 0
-    effectFor: 1
-    reqCode: 2
-  Unstackable: 1
-  Unresettable: 1
+    effectFor: 0
+    reqCode: 0
+  Unstackable: 0
+  Unresettable: 0
   UnstackableAmount: 0
   UnresettableAmount: 0

--- a/Assets/ScriptableObjects/Cards/DegenDefense.asset
+++ b/Assets/ScriptableObjects/Cards/DegenDefense.asset
@@ -20,23 +20,23 @@ MonoBehaviour:
     2, Unresettable 2) Effects do not stack or reset with another card of the same
     name.
   Rarity: 2
-  Type: 1
+  Type: 3
   CardEffectSprite: {fileID: 21300000, guid: 90e1c13e83cf7cf48a7b0d0775f68c94, type: 3}
   AttackPower: 0
   DefensePower: 9
   effectOne:
-    basePower: 2
-    triggeredPower: 3
-    effectTo: 0
-    effectFor: 1
-    reqCode: 8
-  effectMany:
-    power: 2
-    numTurns: 1
+    basePower: 9
+    triggeredPower: 0
     effectTo: 3
+    effectFor: 0
+    reqCode: 0
+  effectMany:
+    power: 1
+    numTurns: 2
+    effectTo: 5
     effectFor: 1
-    reqCode: 4
-  Unstackable: 0
+    reqCode: 0
+  Unstackable: 1
   Unresettable: 1
   UnstackableAmount: 0
   UnresettableAmount: 0

--- a/Assets/ScriptableObjects/Cards/DegenDefense.asset
+++ b/Assets/ScriptableObjects/Cards/DegenDefense.asset
@@ -20,11 +20,23 @@ MonoBehaviour:
     2, Unresettable 2) Effects do not stack or reset with another card of the same
     name.
   Rarity: 2
-  Type: 3
+  Type: 1
   CardEffectSprite: {fileID: 21300000, guid: 90e1c13e83cf7cf48a7b0d0775f68c94, type: 3}
   AttackPower: 0
   DefensePower: 9
+  effectOne:
+    basePower: 2
+    triggeredPower: 3
+    effectTo: 0
+    effectFor: 1
+    reqCode: 8
+  effectMany:
+    power: 2
+    numTurns: 1
+    effectTo: 3
+    effectFor: 1
+    reqCode: 4
   Unstackable: 0
-  Unresettable: 0
+  Unresettable: 1
   UnstackableAmount: 0
   UnresettableAmount: 0

--- a/Assets/ScriptableObjects/Cards/Determination.asset
+++ b/Assets/ScriptableObjects/Cards/Determination.asset
@@ -20,11 +20,23 @@ MonoBehaviour:
     if the current HP is less than 50% than of the start of the battle, the Pepemon
     has an additional +6 Defense until end of turn.
   Rarity: 1
-  Type: 3
+  Type: 1
   CardEffectSprite: {fileID: 21300000, guid: 9846847805228494f8b29dea76d7d117, type: 3}
   AttackPower: 0
   DefensePower: 0
+  effectOne:
+    basePower: 4
+    triggeredPower: 3
+    effectTo: 0
+    effectFor: 1
+    reqCode: 0
+  effectMany:
+    power: 0
+    numTurns: 2
+    effectTo: 5
+    effectFor: 1
+    reqCode: 3
   Unstackable: 0
-  Unresettable: 0
+  Unresettable: 1
   UnstackableAmount: 0
   UnresettableAmount: 0

--- a/Assets/ScriptableObjects/Cards/Determination.asset
+++ b/Assets/ScriptableObjects/Cards/Determination.asset
@@ -20,23 +20,23 @@ MonoBehaviour:
     if the current HP is less than 50% than of the start of the battle, the Pepemon
     has an additional +6 Defense until end of turn.
   Rarity: 1
-  Type: 1
+  Type: 3
   CardEffectSprite: {fileID: 21300000, guid: 9846847805228494f8b29dea76d7d117, type: 3}
   AttackPower: 0
   DefensePower: 0
   effectOne:
-    basePower: 4
-    triggeredPower: 3
-    effectTo: 0
-    effectFor: 1
-    reqCode: 0
+    basePower: 2
+    triggeredPower: 6
+    effectTo: 3
+    effectFor: 0
+    reqCode: 11
   effectMany:
     power: 0
-    numTurns: 2
+    numTurns: 0
     effectTo: 5
     effectFor: 1
-    reqCode: 3
+    reqCode: 0
   Unstackable: 0
-  Unresettable: 1
+  Unresettable: 0
   UnstackableAmount: 0
   UnresettableAmount: 0

--- a/Assets/ScriptableObjects/Cards/DontThinkTooMuch&Strike.asset
+++ b/Assets/ScriptableObjects/Cards/DontThinkTooMuch&Strike.asset
@@ -20,10 +20,22 @@ MonoBehaviour:
     Pepemon\u2019s Intelligence is 5 or less, add an additional +5 more to its Attack
     Power until end of turn."
   Rarity: 1
-  Type: 0
+  Type: 1
   CardEffectSprite: {fileID: 21300000, guid: a950ef2cf0db0b5458521f61299026f4, type: 3}
   AttackPower: 6
   DefensePower: 0
+  effectOne:
+    basePower: 0
+    triggeredPower: 2
+    effectTo: 4
+    effectFor: 1
+    reqCode: 0
+  effectMany:
+    power: 1
+    numTurns: 0
+    effectTo: 5
+    effectFor: 0
+    reqCode: 1
   Unstackable: 0
   Unresettable: 0
   UnstackableAmount: 0

--- a/Assets/ScriptableObjects/Cards/DontThinkTooMuch&Strike.asset
+++ b/Assets/ScriptableObjects/Cards/DontThinkTooMuch&Strike.asset
@@ -20,22 +20,22 @@ MonoBehaviour:
     Pepemon\u2019s Intelligence is 5 or less, add an additional +5 more to its Attack
     Power until end of turn."
   Rarity: 1
-  Type: 1
+  Type: 0
   CardEffectSprite: {fileID: 21300000, guid: a950ef2cf0db0b5458521f61299026f4, type: 3}
   AttackPower: 6
   DefensePower: 0
   effectOne:
-    basePower: 0
-    triggeredPower: 2
-    effectTo: 4
-    effectFor: 1
-    reqCode: 0
-  effectMany:
-    power: 1
-    numTurns: 0
-    effectTo: 5
+    basePower: 1
+    triggeredPower: 6
+    effectTo: 0
     effectFor: 0
     reqCode: 1
+  effectMany:
+    power: 0
+    numTurns: 0
+    effectTo: 0
+    effectFor: 0
+    reqCode: 0
   Unstackable: 0
   Unresettable: 0
   UnstackableAmount: 0

--- a/Assets/ScriptableObjects/Cards/DoubleQuickAttack.asset
+++ b/Assets/ScriptableObjects/Cards/DoubleQuickAttack.asset
@@ -18,22 +18,22 @@ MonoBehaviour:
   DisplayName: Double Quick Attack
   CardDescription: Pepemon adds +4 to its Attack Power until end of turn.
   Rarity: 0
-  Type: 1
+  Type: 0
   CardEffectSprite: {fileID: 21300000, guid: 61e53dfc2f3ad6e46b302965f29cacf3, type: 3}
   AttackPower: 4
   DefensePower: 0
   effectOne:
-    basePower: 0
+    basePower: 4
     triggeredPower: 0
-    effectTo: 1
+    effectTo: 0
     effectFor: 0
-    reqCode: 6
+    reqCode: 0
   effectMany:
-    power: 2
+    power: 0
     numTurns: 0
     effectTo: 0
-    effectFor: 1
-    reqCode: 9
+    effectFor: 0
+    reqCode: 0
   Unstackable: 0
   Unresettable: 0
   UnstackableAmount: 0

--- a/Assets/ScriptableObjects/Cards/DoubleQuickAttack.asset
+++ b/Assets/ScriptableObjects/Cards/DoubleQuickAttack.asset
@@ -22,6 +22,7 @@ MonoBehaviour:
   CardEffectSprite: {fileID: 21300000, guid: 61e53dfc2f3ad6e46b302965f29cacf3, type: 3}
   AttackPower: 4
   DefensePower: 0
+  effectOnes: []
   Unstackable: 0
   Unresettable: 0
   UnstackableAmount: 0

--- a/Assets/ScriptableObjects/Cards/DoubleQuickAttack.asset
+++ b/Assets/ScriptableObjects/Cards/DoubleQuickAttack.asset
@@ -14,15 +14,26 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   UID: b94ce64f-e67c-4395-97ae-67e2e73cb56c
   Icon: {fileID: 0}
-  ID: 17
+  ID: 14
   DisplayName: Double Quick Attack
   CardDescription: Pepemon adds +4 to its Attack Power until end of turn.
   Rarity: 0
-  Type: 0
+  Type: 1
   CardEffectSprite: {fileID: 21300000, guid: 61e53dfc2f3ad6e46b302965f29cacf3, type: 3}
   AttackPower: 4
   DefensePower: 0
-  effectOnes: []
+  effectOne:
+    basePower: 0
+    triggeredPower: 0
+    effectTo: 1
+    effectFor: 0
+    reqCode: 6
+  effectMany:
+    power: 2
+    numTurns: 0
+    effectTo: 0
+    effectFor: 1
+    reqCode: 9
   Unstackable: 0
   Unresettable: 0
   UnstackableAmount: 0

--- a/Assets/ScriptableObjects/Cards/DoubleQuickAttack2.asset
+++ b/Assets/ScriptableObjects/Cards/DoubleQuickAttack2.asset
@@ -10,32 +10,30 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 9e6e5e1c7c6330448a7000c2e43fca97, type: 3}
-  m_Name: FoundAnOpening
+  m_Name: DoubleQuickAttack2
   m_EditorClassIdentifier: 
-  UID: b8e79265-fd2d-4f63-ad56-67fc386ec5ff
+  UID: b94ce64f-e67c-4395-97ae-67e2e73cb56c
   Icon: {fileID: 0}
-  ID: 19
-  DisplayName: Found An Opening
-  CardDescription: Pepemon adds +1 to its Attack Power until end of turn. If the
-    player of the defending Pepemon does not lay any Defense cards, Pepemon adds
-    an additional +7 to its Attack Power until end of turn.
-  Rarity: 1
+  ID: 17
+  DisplayName: Double Quick Attack
+  CardDescription: Pepemon adds +4 to its Attack Power until end of turn.
+  Rarity: 0
   Type: 1
-  CardEffectSprite: {fileID: 21300000, guid: 21b3e2254ddcf2548872f1b6dd0afafe, type: 3}
-  AttackPower: 8
+  CardEffectSprite: {fileID: 21300000, guid: 61e53dfc2f3ad6e46b302965f29cacf3, type: 3}
+  AttackPower: 4
   DefensePower: 0
   effectOne:
     basePower: 2
-    triggeredPower: 1
-    effectTo: 3
+    triggeredPower: 2
+    effectTo: 4
     effectFor: 1
     reqCode: 4
   effectMany:
     power: 3
-    numTurns: 2
+    numTurns: 1
     effectTo: 0
-    effectFor: 1
-    reqCode: 8
+    effectFor: 0
+    reqCode: 3
   Unstackable: 1
   Unresettable: 0
   UnstackableAmount: 0

--- a/Assets/ScriptableObjects/Cards/DoubleQuickAttack2.asset
+++ b/Assets/ScriptableObjects/Cards/DoubleQuickAttack2.asset
@@ -18,23 +18,23 @@ MonoBehaviour:
   DisplayName: Double Quick Attack
   CardDescription: Pepemon adds +4 to its Attack Power until end of turn.
   Rarity: 0
-  Type: 1
+  Type: 0
   CardEffectSprite: {fileID: 21300000, guid: 61e53dfc2f3ad6e46b302965f29cacf3, type: 3}
   AttackPower: 4
   DefensePower: 0
   effectOne:
-    basePower: 2
-    triggeredPower: 2
-    effectTo: 4
-    effectFor: 1
-    reqCode: 4
-  effectMany:
-    power: 3
-    numTurns: 1
+    basePower: 4
+    triggeredPower: 0
     effectTo: 0
     effectFor: 0
-    reqCode: 3
-  Unstackable: 1
+    reqCode: 0
+  effectMany:
+    power: 0
+    numTurns: 0
+    effectTo: 0
+    effectFor: 0
+    reqCode: 0
+  Unstackable: 0
   Unresettable: 0
   UnstackableAmount: 0
   UnresettableAmount: 0

--- a/Assets/ScriptableObjects/Cards/DoubleQuickAttack2.asset.meta
+++ b/Assets/ScriptableObjects/Cards/DoubleQuickAttack2.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7e690757586d21141846a8be64cc64cc
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ScriptableObjects/Cards/DoubleTeam.asset
+++ b/Assets/ScriptableObjects/Cards/DoubleTeam.asset
@@ -19,22 +19,22 @@ MonoBehaviour:
   CardDescription: Pepemon adds +6 to its Defense Power for each +3 Defense card
     used by its player during this turn.
   Rarity: 1
-  Type: 1
+  Type: 2
   CardEffectSprite: {fileID: 21300000, guid: 4f4b8256b75048849b0ff38168541a17, type: 3}
   AttackPower: 0
   DefensePower: 6
   effectOne:
-    basePower: 2
-    triggeredPower: 4
-    effectTo: 5
+    basePower: 6
+    triggeredPower: 6
+    effectTo: 2
     effectFor: 0
-    reqCode: 1
+    reqCode: 6
   effectMany:
-    power: 3
-    numTurns: 2
-    effectTo: 5
-    effectFor: 1
-    reqCode: 3
+    power: 0
+    numTurns: 0
+    effectTo: 0
+    effectFor: 0
+    reqCode: 0
   Unstackable: 0
   Unresettable: 0
   UnstackableAmount: 0

--- a/Assets/ScriptableObjects/Cards/DoubleTeam.asset
+++ b/Assets/ScriptableObjects/Cards/DoubleTeam.asset
@@ -19,10 +19,22 @@ MonoBehaviour:
   CardDescription: Pepemon adds +6 to its Defense Power for each +3 Defense card
     used by its player during this turn.
   Rarity: 1
-  Type: 2
+  Type: 1
   CardEffectSprite: {fileID: 21300000, guid: 4f4b8256b75048849b0ff38168541a17, type: 3}
   AttackPower: 0
   DefensePower: 6
+  effectOne:
+    basePower: 2
+    triggeredPower: 4
+    effectTo: 5
+    effectFor: 0
+    reqCode: 1
+  effectMany:
+    power: 3
+    numTurns: 2
+    effectTo: 5
+    effectFor: 1
+    reqCode: 3
   Unstackable: 0
   Unresettable: 0
   UnstackableAmount: 0

--- a/Assets/ScriptableObjects/Cards/DueDilligence.asset
+++ b/Assets/ScriptableObjects/Cards/DueDilligence.asset
@@ -20,11 +20,23 @@ MonoBehaviour:
     2, Unresettable 2) Effects do not stack or reset with another card of the same
     name.
   Rarity: 2
-  Type: 3
+  Type: 1
   CardEffectSprite: {fileID: 21300000, guid: beb5ea5b2d4548a4c84f48eb9f6f25da, type: 3}
   AttackPower: 0
   DefensePower: 0
+  effectOne:
+    basePower: 0
+    triggeredPower: 4
+    effectTo: 3
+    effectFor: 1
+    reqCode: 9
+  effectMany:
+    power: 1
+    numTurns: 0
+    effectTo: 0
+    effectFor: 1
+    reqCode: 1
   Unstackable: 1
-  Unresettable: 1
-  UnstackableAmount: 2
+  Unresettable: 0
+  UnstackableAmount: 0
   UnresettableAmount: 2

--- a/Assets/ScriptableObjects/Cards/DueDilligence.asset
+++ b/Assets/ScriptableObjects/Cards/DueDilligence.asset
@@ -20,23 +20,23 @@ MonoBehaviour:
     2, Unresettable 2) Effects do not stack or reset with another card of the same
     name.
   Rarity: 2
-  Type: 1
+  Type: 3
   CardEffectSprite: {fileID: 21300000, guid: beb5ea5b2d4548a4c84f48eb9f6f25da, type: 3}
   AttackPower: 0
   DefensePower: 0
   effectOne:
     basePower: 0
-    triggeredPower: 4
-    effectTo: 3
-    effectFor: 1
-    reqCode: 9
+    triggeredPower: 0
+    effectTo: 0
+    effectFor: 0
+    reqCode: 0
   effectMany:
     power: 1
-    numTurns: 0
-    effectTo: 0
-    effectFor: 1
-    reqCode: 1
+    numTurns: 2
+    effectTo: 5
+    effectFor: 0
+    reqCode: 0
   Unstackable: 1
-  Unresettable: 0
+  Unresettable: 1
   UnstackableAmount: 0
   UnresettableAmount: 2

--- a/Assets/ScriptableObjects/Cards/ExtremeSpeed.asset
+++ b/Assets/ScriptableObjects/Cards/ExtremeSpeed.asset
@@ -23,7 +23,19 @@ MonoBehaviour:
   CardEffectSprite: {fileID: 21300000, guid: 7f00fd3803674764798b5e98f12e0e50, type: 3}
   AttackPower: 0
   DefensePower: 0
-  Unstackable: 1
-  Unresettable: 1
+  effectOne:
+    basePower: 1
+    triggeredPower: 4
+    effectTo: 4
+    effectFor: 0
+    reqCode: 9
+  effectMany:
+    power: 2
+    numTurns: 1
+    effectTo: 4
+    effectFor: 1
+    reqCode: 5
+  Unstackable: 0
+  Unresettable: 0
   UnstackableAmount: 3
   UnresettableAmount: 3

--- a/Assets/ScriptableObjects/Cards/ExtremeSpeed.asset
+++ b/Assets/ScriptableObjects/Cards/ExtremeSpeed.asset
@@ -24,18 +24,18 @@ MonoBehaviour:
   AttackPower: 0
   DefensePower: 0
   effectOne:
-    basePower: 1
-    triggeredPower: 4
+    basePower: 0
+    triggeredPower: 0
+    effectTo: 0
+    effectFor: 0
+    reqCode: 0
+  effectMany:
+    power: 5
+    numTurns: 3
     effectTo: 4
     effectFor: 0
-    reqCode: 9
-  effectMany:
-    power: 2
-    numTurns: 1
-    effectTo: 4
-    effectFor: 1
-    reqCode: 5
-  Unstackable: 0
-  Unresettable: 0
+    reqCode: 0
+  Unstackable: 1
+  Unresettable: 1
   UnstackableAmount: 3
   UnresettableAmount: 3

--- a/Assets/ScriptableObjects/Cards/FlameClone.asset
+++ b/Assets/ScriptableObjects/Cards/FlameClone.asset
@@ -20,23 +20,23 @@ MonoBehaviour:
     If the attacking Pepemon has 5 or less Intelligence, attacking Pepemon gets a
     further -4 Attack Power until end of turn.
   Rarity: 1
-  Type: 1
+  Type: 2
   CardEffectSprite: {fileID: 21300000, guid: 44872bd33239a2d4d889b37f49258642, type: 3}
   AttackPower: 0
   DefensePower: 0
   effectOne:
-    basePower: 3
-    triggeredPower: 2
+    basePower: -3
+    triggeredPower: -7
     effectTo: 0
-    effectFor: 0
-    reqCode: 11
+    effectFor: 1
+    reqCode: 8
   effectMany:
     power: 0
     numTurns: 0
-    effectTo: 2
+    effectTo: 0
     effectFor: 0
-    reqCode: 9
-  Unstackable: 1
+    reqCode: 0
+  Unstackable: 0
   Unresettable: 0
   UnstackableAmount: 0
   UnresettableAmount: 0

--- a/Assets/ScriptableObjects/Cards/FlameClone.asset
+++ b/Assets/ScriptableObjects/Cards/FlameClone.asset
@@ -20,11 +20,23 @@ MonoBehaviour:
     If the attacking Pepemon has 5 or less Intelligence, attacking Pepemon gets a
     further -4 Attack Power until end of turn.
   Rarity: 1
-  Type: 2
+  Type: 1
   CardEffectSprite: {fileID: 21300000, guid: 44872bd33239a2d4d889b37f49258642, type: 3}
   AttackPower: 0
   DefensePower: 0
-  Unstackable: 0
+  effectOne:
+    basePower: 3
+    triggeredPower: 2
+    effectTo: 0
+    effectFor: 0
+    reqCode: 11
+  effectMany:
+    power: 0
+    numTurns: 0
+    effectTo: 2
+    effectFor: 0
+    reqCode: 9
+  Unstackable: 1
   Unresettable: 0
   UnstackableAmount: 0
   UnresettableAmount: 0

--- a/Assets/ScriptableObjects/Cards/FoundAnOpening.asset
+++ b/Assets/ScriptableObjects/Cards/FoundAnOpening.asset
@@ -20,23 +20,23 @@ MonoBehaviour:
     player of the defending Pepemon does not lay any Defense cards, Pepemon adds
     an additional +7 to its Attack Power until end of turn.
   Rarity: 1
-  Type: 1
+  Type: 0
   CardEffectSprite: {fileID: 21300000, guid: 21b3e2254ddcf2548872f1b6dd0afafe, type: 3}
   AttackPower: 8
   DefensePower: 0
   effectOne:
-    basePower: 2
-    triggeredPower: 1
-    effectTo: 3
-    effectFor: 1
-    reqCode: 4
+    basePower: 1
+    triggeredPower: 8
+    effectTo: 2
+    effectFor: 0
+    reqCode: 2
   effectMany:
-    power: 3
-    numTurns: 2
+    power: 0
+    numTurns: 0
     effectTo: 0
-    effectFor: 1
-    reqCode: 8
-  Unstackable: 1
+    effectFor: 0
+    reqCode: 0
+  Unstackable: 0
   Unresettable: 0
   UnstackableAmount: 0
   UnresettableAmount: 0

--- a/Assets/ScriptableObjects/Cards/HyperFang.asset
+++ b/Assets/ScriptableObjects/Cards/HyperFang.asset
@@ -24,18 +24,18 @@ MonoBehaviour:
   AttackPower: 6
   DefensePower: 0
   effectOne:
-    basePower: 3
-    triggeredPower: 4
+    basePower: 6
+    triggeredPower: 3
     effectTo: 1
-    effectFor: 1
-    reqCode: 7
-  effectMany:
-    power: 2
-    numTurns: 0
-    effectTo: 1
-    effectFor: 1
+    effectFor: 0
     reqCode: 4
-  Unstackable: 1
-  Unresettable: 1
+  effectMany:
+    power: 0
+    numTurns: 0
+    effectTo: 0
+    effectFor: 0
+    reqCode: 0
+  Unstackable: 0
+  Unresettable: 0
   UnstackableAmount: 0
   UnresettableAmount: 0

--- a/Assets/ScriptableObjects/Cards/HyperFang.asset
+++ b/Assets/ScriptableObjects/Cards/HyperFang.asset
@@ -23,7 +23,19 @@ MonoBehaviour:
   CardEffectSprite: {fileID: 21300000, guid: 4982f857cbf6e2b49be974ec03ab59d6, type: 3}
   AttackPower: 6
   DefensePower: 0
-  Unstackable: 0
-  Unresettable: 0
+  effectOne:
+    basePower: 3
+    triggeredPower: 4
+    effectTo: 1
+    effectFor: 1
+    reqCode: 7
+  effectMany:
+    power: 2
+    numTurns: 0
+    effectTo: 1
+    effectFor: 1
+    reqCode: 4
+  Unstackable: 1
+  Unresettable: 1
   UnstackableAmount: 0
   UnresettableAmount: 0

--- a/Assets/ScriptableObjects/Cards/IReadYouLikeABook.asset
+++ b/Assets/ScriptableObjects/Cards/IReadYouLikeABook.asset
@@ -20,10 +20,22 @@ MonoBehaviour:
     adds an additional +10 to its Defense Power until end of turn, if the attacking
     Pepemon used its strong attack this turn.
   Rarity: 1
-  Type: 3
+  Type: 1
   CardEffectSprite: {fileID: 21300000, guid: 86f3adde04f43a041ac6d8aefe951833, type: 3}
   AttackPower: 0
   DefensePower: 12
+  effectOne:
+    basePower: 1
+    triggeredPower: 4
+    effectTo: 4
+    effectFor: 0
+    reqCode: 11
+  effectMany:
+    power: 4
+    numTurns: 0
+    effectTo: 2
+    effectFor: 0
+    reqCode: 10
   Unstackable: 0
   Unresettable: 0
   UnstackableAmount: 0

--- a/Assets/ScriptableObjects/Cards/IReadYouLikeABook.asset
+++ b/Assets/ScriptableObjects/Cards/IReadYouLikeABook.asset
@@ -20,22 +20,22 @@ MonoBehaviour:
     adds an additional +10 to its Defense Power until end of turn, if the attacking
     Pepemon used its strong attack this turn.
   Rarity: 1
-  Type: 1
+  Type: 3
   CardEffectSprite: {fileID: 21300000, guid: 86f3adde04f43a041ac6d8aefe951833, type: 3}
   AttackPower: 0
   DefensePower: 12
   effectOne:
-    basePower: 1
-    triggeredPower: 4
-    effectTo: 4
-    effectFor: 0
-    reqCode: 11
-  effectMany:
-    power: 4
-    numTurns: 0
+    basePower: 2
+    triggeredPower: 12
     effectTo: 2
     effectFor: 0
     reqCode: 10
+  effectMany:
+    power: 0
+    numTurns: 0
+    effectTo: 0
+    effectFor: 0
+    reqCode: 0
   Unstackable: 0
   Unresettable: 0
   UnstackableAmount: 0

--- a/Assets/ScriptableObjects/Cards/Inflate.asset
+++ b/Assets/ScriptableObjects/Cards/Inflate.asset
@@ -25,18 +25,18 @@ MonoBehaviour:
   AttackPower: -7
   DefensePower: 0
   effectOne:
-    basePower: 3
-    triggeredPower: 4
-    effectTo: 4
+    basePower: -7
+    triggeredPower: 0
+    effectTo: 1
     effectFor: 0
-    reqCode: 1
+    reqCode: 0
   effectMany:
-    power: 2
-    numTurns: 1
+    power: 7
+    numTurns: 2
     effectTo: 0
     effectFor: 0
-    reqCode: 5
-  Unstackable: 0
-  Unresettable: 0
+    reqCode: 0
+  Unstackable: 1
+  Unresettable: 1
   UnstackableAmount: 2
   UnresettableAmount: 2

--- a/Assets/ScriptableObjects/Cards/Inflate.asset
+++ b/Assets/ScriptableObjects/Cards/Inflate.asset
@@ -24,7 +24,19 @@ MonoBehaviour:
   CardEffectSprite: {fileID: 21300000, guid: 7a39e7958d052564b813988b9d28f22d, type: 3}
   AttackPower: -7
   DefensePower: 0
-  Unstackable: 1
-  Unresettable: 1
+  effectOne:
+    basePower: 3
+    triggeredPower: 4
+    effectTo: 4
+    effectFor: 0
+    reqCode: 1
+  effectMany:
+    power: 2
+    numTurns: 1
+    effectTo: 0
+    effectFor: 0
+    reqCode: 5
+  Unstackable: 0
+  Unresettable: 0
   UnstackableAmount: 2
   UnresettableAmount: 2

--- a/Assets/ScriptableObjects/Cards/InvestedPower.asset
+++ b/Assets/ScriptableObjects/Cards/InvestedPower.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   UID: 37e6bad2-733a-4663-8d9f-31d664d1f434
   Icon: {fileID: 0}
-  ID: 24
+  ID: 23
   DisplayName: Invested Power
   CardDescription: "If the Pepemon\u2019s Intelligence is 5 or less, then until end
     of turn, the Pepemon receives an additional Attack Power equal to the total of
@@ -24,7 +24,19 @@ MonoBehaviour:
   CardEffectSprite: {fileID: 21300000, guid: 4b959a362f896784cbd7ca626958f560, type: 3}
   AttackPower: 4
   DefensePower: 0
-  Unstackable: 0
+  effectOne:
+    basePower: 3
+    triggeredPower: 4
+    effectTo: 3
+    effectFor: 0
+    reqCode: 1
+  effectMany:
+    power: 2
+    numTurns: 2
+    effectTo: 3
+    effectFor: 0
+    reqCode: 10
+  Unstackable: 1
   Unresettable: 0
   UnstackableAmount: 0
   UnresettableAmount: 0

--- a/Assets/ScriptableObjects/Cards/InvestedPower.asset
+++ b/Assets/ScriptableObjects/Cards/InvestedPower.asset
@@ -25,18 +25,18 @@ MonoBehaviour:
   AttackPower: 4
   DefensePower: 0
   effectOne:
-    basePower: 3
-    triggeredPower: 4
-    effectTo: 3
+    basePower: 0
+    triggeredPower: 0
+    effectTo: 1
     effectFor: 0
     reqCode: 1
   effectMany:
-    power: 2
-    numTurns: 2
-    effectTo: 3
+    power: 0
+    numTurns: 0
+    effectTo: 0
     effectFor: 0
-    reqCode: 10
-  Unstackable: 1
+    reqCode: 0
+  Unstackable: 0
   Unresettable: 0
   UnstackableAmount: 0
   UnresettableAmount: 0

--- a/Assets/ScriptableObjects/Cards/MudSlide.asset
+++ b/Assets/ScriptableObjects/Cards/MudSlide.asset
@@ -20,11 +20,23 @@ MonoBehaviour:
     turn and the next 2 turns. (Unstackable 2, Unresettable 2). Effects do not stack
     with another card of the same name.
   Rarity: 1
-  Type: 3
+  Type: 1
   CardEffectSprite: {fileID: 21300000, guid: 6fc863e8f9486784dbe6a383f3c3c5c2, type: 3}
   AttackPower: 0
   DefensePower: 0
-  Unstackable: 1
+  effectOne:
+    basePower: 2
+    triggeredPower: 2
+    effectTo: 2
+    effectFor: 0
+    reqCode: 7
+  effectMany:
+    power: 2
+    numTurns: 1
+    effectTo: 1
+    effectFor: 0
+    reqCode: 11
+  Unstackable: 0
   Unresettable: 1
   UnstackableAmount: 2
-  UnresettableAmount: 2
+  UnresettableAmount: 0

--- a/Assets/ScriptableObjects/Cards/MudSlide.asset
+++ b/Assets/ScriptableObjects/Cards/MudSlide.asset
@@ -20,23 +20,23 @@ MonoBehaviour:
     turn and the next 2 turns. (Unstackable 2, Unresettable 2). Effects do not stack
     with another card of the same name.
   Rarity: 1
-  Type: 1
+  Type: 3
   CardEffectSprite: {fileID: 21300000, guid: 6fc863e8f9486784dbe6a383f3c3c5c2, type: 3}
   AttackPower: 0
   DefensePower: 0
   effectOne:
-    basePower: 2
-    triggeredPower: 2
-    effectTo: 2
-    effectFor: 0
-    reqCode: 7
+    basePower: -3
+    triggeredPower: 0
+    effectTo: 0
+    effectFor: 1
+    reqCode: 0
   effectMany:
-    power: 2
-    numTurns: 1
-    effectTo: 1
-    effectFor: 0
-    reqCode: 11
-  Unstackable: 0
+    power: -3
+    numTurns: 2
+    effectTo: 0
+    effectFor: 1
+    reqCode: 0
+  Unstackable: 1
   Unresettable: 1
   UnstackableAmount: 2
   UnresettableAmount: 0

--- a/Assets/ScriptableObjects/Cards/OilSlick.asset
+++ b/Assets/ScriptableObjects/Cards/OilSlick.asset
@@ -20,23 +20,23 @@ MonoBehaviour:
     turn and the next 3 turns. (Unstackable 3, Unresettable 3) Effects do not stack
     with another card of the same name.
   Rarity: 1
-  Type: 1
+  Type: 3
   CardEffectSprite: {fileID: 21300000, guid: 9f0ae1ade0126f542a6a13833ee7b4d1, type: 3}
   AttackPower: 0
   DefensePower: 0
   effectOne:
-    basePower: 2
+    basePower: -2
     triggeredPower: 0
-    effectTo: 2
-    effectFor: 0
-    reqCode: 3
-  effectMany:
-    power: 0
-    numTurns: 1
     effectTo: 0
-    effectFor: 0
-    reqCode: 2
-  Unstackable: 0
+    effectFor: 1
+    reqCode: 0
+  effectMany:
+    power: -2
+    numTurns: 3
+    effectTo: 0
+    effectFor: 1
+    reqCode: 0
+  Unstackable: 1
   Unresettable: 1
   UnstackableAmount: 3
   UnresettableAmount: 0

--- a/Assets/ScriptableObjects/Cards/OilSlick.asset
+++ b/Assets/ScriptableObjects/Cards/OilSlick.asset
@@ -20,11 +20,23 @@ MonoBehaviour:
     turn and the next 3 turns. (Unstackable 3, Unresettable 3) Effects do not stack
     with another card of the same name.
   Rarity: 1
-  Type: 3
+  Type: 1
   CardEffectSprite: {fileID: 21300000, guid: 9f0ae1ade0126f542a6a13833ee7b4d1, type: 3}
   AttackPower: 0
   DefensePower: 0
-  Unstackable: 1
+  effectOne:
+    basePower: 2
+    triggeredPower: 0
+    effectTo: 2
+    effectFor: 0
+    reqCode: 3
+  effectMany:
+    power: 0
+    numTurns: 1
+    effectTo: 0
+    effectFor: 0
+    reqCode: 2
+  Unstackable: 0
   Unresettable: 1
   UnstackableAmount: 3
-  UnresettableAmount: 3
+  UnresettableAmount: 0

--- a/Assets/ScriptableObjects/Cards/Parry.asset
+++ b/Assets/ScriptableObjects/Cards/Parry.asset
@@ -19,21 +19,21 @@ MonoBehaviour:
   CardDescription: Pepemon adds +5 to its Defense Power for each +4 Defense card
     used by the player during this turn
   Rarity: 1
-  Type: 1
+  Type: 2
   CardEffectSprite: {fileID: 21300000, guid: 43d8d0120a29e0546aa2d86d7a1a44ce, type: 3}
   AttackPower: 0
   DefensePower: 5
   effectOne:
-    basePower: 2
+    basePower: 5
     triggeredPower: 0
-    effectTo: 1
-    effectFor: 1
-    reqCode: 3
-  effectMany:
-    power: 4
-    numTurns: 1
     effectTo: 2
     effectFor: 1
+    reqCode: 7
+  effectMany:
+    power: 0
+    numTurns: 0
+    effectTo: 0
+    effectFor: 0
     reqCode: 0
   Unstackable: 0
   Unresettable: 0

--- a/Assets/ScriptableObjects/Cards/PitTrap.asset
+++ b/Assets/ScriptableObjects/Cards/PitTrap.asset
@@ -20,22 +20,22 @@ MonoBehaviour:
     the next 3 turns. (Unstackable 3, Unresettable 3) Effects do not stack with another
     card of the same name.
   Rarity: 1
-  Type: 1
+  Type: 3
   CardEffectSprite: {fileID: 21300000, guid: 29caaf971c121244d91ecf5784c836a7, type: 3}
   AttackPower: 0
   DefensePower: 0
   effectOne:
-    basePower: 4
+    basePower: -2
     triggeredPower: 0
-    effectTo: 3
-    effectFor: 0
+    effectTo: 2
+    effectFor: 1
     reqCode: 0
   effectMany:
-    power: 1
-    numTurns: 0
-    effectTo: 3
-    effectFor: 0
-    reqCode: 8
+    power: -2
+    numTurns: 3
+    effectTo: 2
+    effectFor: 1
+    reqCode: 0
   Unstackable: 1
   Unresettable: 1
   UnstackableAmount: 0

--- a/Assets/ScriptableObjects/Cards/PitTrap.asset
+++ b/Assets/ScriptableObjects/Cards/PitTrap.asset
@@ -20,11 +20,23 @@ MonoBehaviour:
     the next 3 turns. (Unstackable 3, Unresettable 3) Effects do not stack with another
     card of the same name.
   Rarity: 1
-  Type: 3
+  Type: 1
   CardEffectSprite: {fileID: 21300000, guid: 29caaf971c121244d91ecf5784c836a7, type: 3}
   AttackPower: 0
   DefensePower: 0
+  effectOne:
+    basePower: 4
+    triggeredPower: 0
+    effectTo: 3
+    effectFor: 0
+    reqCode: 0
+  effectMany:
+    power: 1
+    numTurns: 0
+    effectTo: 3
+    effectFor: 0
+    reqCode: 8
   Unstackable: 1
   Unresettable: 1
-  UnstackableAmount: 3
-  UnresettableAmount: 3
+  UnstackableAmount: 0
+  UnresettableAmount: 0

--- a/Assets/ScriptableObjects/Cards/PoisonFang.asset
+++ b/Assets/ScriptableObjects/Cards/PoisonFang.asset
@@ -19,11 +19,23 @@ MonoBehaviour:
   CardDescription: Pepemon gets +1 to its Attack Power until end of turn, while the
     target defending Pepemon gets -4 to its Defense Power until end of turn.
   Rarity: 1
-  Type: 0
+  Type: 1
   CardEffectSprite: {fileID: 21300000, guid: 66bcc350d628be24d85e59188bc10885, type: 3}
   AttackPower: 0
   DefensePower: 0
-  Unstackable: 0
+  effectOne:
+    basePower: 4
+    triggeredPower: 2
+    effectTo: 3
+    effectFor: 0
+    reqCode: 2
+  effectMany:
+    power: 4
+    numTurns: 1
+    effectTo: 0
+    effectFor: 1
+    reqCode: 11
+  Unstackable: 1
   Unresettable: 0
   UnstackableAmount: 0
   UnresettableAmount: 0

--- a/Assets/ScriptableObjects/Cards/PoisonFang.asset
+++ b/Assets/ScriptableObjects/Cards/PoisonFang.asset
@@ -19,23 +19,23 @@ MonoBehaviour:
   CardDescription: Pepemon gets +1 to its Attack Power until end of turn, while the
     target defending Pepemon gets -4 to its Defense Power until end of turn.
   Rarity: 1
-  Type: 1
+  Type: 0
   CardEffectSprite: {fileID: 21300000, guid: 66bcc350d628be24d85e59188bc10885, type: 3}
   AttackPower: 0
   DefensePower: 0
   effectOne:
-    basePower: 4
-    triggeredPower: 2
-    effectTo: 3
-    effectFor: 0
-    reqCode: 2
+    basePower: -4
+    triggeredPower: 0
+    effectTo: 2
+    effectFor: 1
+    reqCode: 0
   effectMany:
-    power: 4
+    power: 1
     numTurns: 1
     effectTo: 0
-    effectFor: 1
-    reqCode: 11
-  Unstackable: 1
+    effectFor: 0
+    reqCode: 0
+  Unstackable: 0
   Unresettable: 0
   UnstackableAmount: 0
   UnresettableAmount: 0

--- a/Assets/ScriptableObjects/Cards/PowerSurge.asset
+++ b/Assets/ScriptableObjects/Cards/PowerSurge.asset
@@ -24,7 +24,19 @@ MonoBehaviour:
   CardEffectSprite: {fileID: 21300000, guid: 00262663392268f42bf6dbedb9b16cdc, type: 3}
   AttackPower: -10
   DefensePower: 0
-  Unstackable: 1
+  effectOne:
+    basePower: 1
+    triggeredPower: 0
+    effectTo: 3
+    effectFor: 0
+    reqCode: 2
+  effectMany:
+    power: 3
+    numTurns: 0
+    effectTo: 1
+    effectFor: 1
+    reqCode: 6
+  Unstackable: 0
   Unresettable: 1
   UnstackableAmount: 2
-  UnresettableAmount: 2
+  UnresettableAmount: 0

--- a/Assets/ScriptableObjects/Cards/PowerSurge.asset
+++ b/Assets/ScriptableObjects/Cards/PowerSurge.asset
@@ -25,18 +25,18 @@ MonoBehaviour:
   AttackPower: -10
   DefensePower: 0
   effectOne:
-    basePower: 1
+    basePower: -10
     triggeredPower: 0
-    effectTo: 3
+    effectTo: 0
     effectFor: 0
-    reqCode: 2
+    reqCode: 0
   effectMany:
-    power: 3
-    numTurns: 0
-    effectTo: 1
-    effectFor: 1
-    reqCode: 6
-  Unstackable: 0
+    power: 10
+    numTurns: 2
+    effectTo: 0
+    effectFor: 0
+    reqCode: 0
+  Unstackable: 1
   Unresettable: 1
   UnstackableAmount: 2
   UnresettableAmount: 0

--- a/Assets/ScriptableObjects/Cards/PrettyQuickAttack.asset
+++ b/Assets/ScriptableObjects/Cards/PrettyQuickAttack.asset
@@ -22,6 +22,7 @@ MonoBehaviour:
   CardEffectSprite: {fileID: 21300000, guid: d95fed4a4095d1f4b9306bb8735a0d1b, type: 3}
   AttackPower: 2
   DefensePower: 0
+  effectOnes: []
   Unstackable: 0
   Unresettable: 0
   UnstackableAmount: 0

--- a/Assets/ScriptableObjects/Cards/PrettyQuickAttack.asset
+++ b/Assets/ScriptableObjects/Cards/PrettyQuickAttack.asset
@@ -18,23 +18,23 @@ MonoBehaviour:
   DisplayName: Pretty Quick Attack
   CardDescription: Pepemon adds +2 to its Attack Power until end of turn.
   Rarity: 0
-  Type: 1
+  Type: 0
   CardEffectSprite: {fileID: 21300000, guid: d95fed4a4095d1f4b9306bb8735a0d1b, type: 3}
   AttackPower: 2
   DefensePower: 0
   effectOne:
-    basePower: 3
-    triggeredPower: 1
-    effectTo: 2
-    effectFor: 1
-    reqCode: 2
+    basePower: 2
+    triggeredPower: 0
+    effectTo: 0
+    effectFor: 0
+    reqCode: 0
   effectMany:
-    power: 4
+    power: 0
     numTurns: 0
-    effectTo: 1
-    effectFor: 1
-    reqCode: 6
-  Unstackable: 1
-  Unresettable: 1
+    effectTo: 0
+    effectFor: 0
+    reqCode: 0
+  Unstackable: 0
+  Unresettable: 0
   UnstackableAmount: 0
   UnresettableAmount: 0

--- a/Assets/ScriptableObjects/Cards/PrettyQuickAttack.asset
+++ b/Assets/ScriptableObjects/Cards/PrettyQuickAttack.asset
@@ -14,16 +14,27 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   UID: bfb2add8-08d7-40b1-ab03-303c8bfb2e0f
   Icon: {fileID: 0}
-  ID: 15
+  ID: 11
   DisplayName: Pretty Quick Attack
   CardDescription: Pepemon adds +2 to its Attack Power until end of turn.
   Rarity: 0
-  Type: 0
+  Type: 1
   CardEffectSprite: {fileID: 21300000, guid: d95fed4a4095d1f4b9306bb8735a0d1b, type: 3}
   AttackPower: 2
   DefensePower: 0
-  effectOnes: []
-  Unstackable: 0
-  Unresettable: 0
+  effectOne:
+    basePower: 3
+    triggeredPower: 1
+    effectTo: 2
+    effectFor: 1
+    reqCode: 2
+  effectMany:
+    power: 4
+    numTurns: 0
+    effectTo: 1
+    effectFor: 1
+    reqCode: 6
+  Unstackable: 1
+  Unresettable: 1
   UnstackableAmount: 0
   UnresettableAmount: 0

--- a/Assets/ScriptableObjects/Cards/PrettyQuickAttack2.asset
+++ b/Assets/ScriptableObjects/Cards/PrettyQuickAttack2.asset
@@ -18,23 +18,23 @@ MonoBehaviour:
   DisplayName: Pretty Quick Attack
   CardDescription: Pepemon adds +2 to its Attack Power until end of turn.
   Rarity: 0
-  Type: 1
+  Type: 0
   CardEffectSprite: {fileID: 21300000, guid: d95fed4a4095d1f4b9306bb8735a0d1b, type: 3}
   AttackPower: 2
   DefensePower: 0
   effectOne:
     basePower: 2
-    triggeredPower: 4
+    triggeredPower: 0
     effectTo: 0
     effectFor: 0
-    reqCode: 2
+    reqCode: 0
   effectMany:
-    power: 3
-    numTurns: 2
-    effectTo: 4
-    effectFor: 1
-    reqCode: 3
-  Unstackable: 1
-  Unresettable: 1
+    power: 0
+    numTurns: 0
+    effectTo: 0
+    effectFor: 0
+    reqCode: 0
+  Unstackable: 0
+  Unresettable: 0
   UnstackableAmount: 0
   UnresettableAmount: 0

--- a/Assets/ScriptableObjects/Cards/PrettyQuickAttack2.asset
+++ b/Assets/ScriptableObjects/Cards/PrettyQuickAttack2.asset
@@ -10,33 +10,31 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 9e6e5e1c7c6330448a7000c2e43fca97, type: 3}
-  m_Name: FoundAnOpening
+  m_Name: PrettyQuickAttack2
   m_EditorClassIdentifier: 
-  UID: b8e79265-fd2d-4f63-ad56-67fc386ec5ff
+  UID: bfb2add8-08d7-40b1-ab03-303c8bfb2e0f
   Icon: {fileID: 0}
-  ID: 19
-  DisplayName: Found An Opening
-  CardDescription: Pepemon adds +1 to its Attack Power until end of turn. If the
-    player of the defending Pepemon does not lay any Defense cards, Pepemon adds
-    an additional +7 to its Attack Power until end of turn.
-  Rarity: 1
+  ID: 12
+  DisplayName: Pretty Quick Attack
+  CardDescription: Pepemon adds +2 to its Attack Power until end of turn.
+  Rarity: 0
   Type: 1
-  CardEffectSprite: {fileID: 21300000, guid: 21b3e2254ddcf2548872f1b6dd0afafe, type: 3}
-  AttackPower: 8
+  CardEffectSprite: {fileID: 21300000, guid: d95fed4a4095d1f4b9306bb8735a0d1b, type: 3}
+  AttackPower: 2
   DefensePower: 0
   effectOne:
     basePower: 2
-    triggeredPower: 1
-    effectTo: 3
-    effectFor: 1
-    reqCode: 4
+    triggeredPower: 4
+    effectTo: 0
+    effectFor: 0
+    reqCode: 2
   effectMany:
     power: 3
     numTurns: 2
-    effectTo: 0
+    effectTo: 4
     effectFor: 1
-    reqCode: 8
+    reqCode: 3
   Unstackable: 1
-  Unresettable: 0
+  Unresettable: 1
   UnstackableAmount: 0
   UnresettableAmount: 0

--- a/Assets/ScriptableObjects/Cards/PrettyQuickAttack2.asset.meta
+++ b/Assets/ScriptableObjects/Cards/PrettyQuickAttack2.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a9ae4a580404c38418bb606dee25aca5
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ScriptableObjects/Cards/PrettyQuickAttack3.asset
+++ b/Assets/ScriptableObjects/Cards/PrettyQuickAttack3.asset
@@ -10,32 +10,31 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 9e6e5e1c7c6330448a7000c2e43fca97, type: 3}
-  m_Name: Parry
+  m_Name: PrettyQuickAttack3
   m_EditorClassIdentifier: 
-  UID: 5e370533-afa6-425b-b31f-58e3797b4e66
+  UID: bfb2add8-08d7-40b1-ab03-303c8bfb2e0f
   Icon: {fileID: 0}
-  ID: 31
-  DisplayName: Perry
-  CardDescription: Pepemon adds +5 to its Defense Power for each +4 Defense card
-    used by the player during this turn
-  Rarity: 1
+  ID: 15
+  DisplayName: Pretty Quick Attack
+  CardDescription: Pepemon adds +2 to its Attack Power until end of turn.
+  Rarity: 0
   Type: 1
-  CardEffectSprite: {fileID: 21300000, guid: 43d8d0120a29e0546aa2d86d7a1a44ce, type: 3}
-  AttackPower: 0
-  DefensePower: 5
+  CardEffectSprite: {fileID: 21300000, guid: d95fed4a4095d1f4b9306bb8735a0d1b, type: 3}
+  AttackPower: 2
+  DefensePower: 0
   effectOne:
-    basePower: 2
-    triggeredPower: 0
-    effectTo: 1
+    basePower: 0
+    triggeredPower: 4
+    effectTo: 4
     effectFor: 1
     reqCode: 3
   effectMany:
-    power: 4
-    numTurns: 1
-    effectTo: 2
-    effectFor: 1
-    reqCode: 0
-  Unstackable: 0
+    power: 1
+    numTurns: 0
+    effectTo: 4
+    effectFor: 0
+    reqCode: 8
+  Unstackable: 1
   Unresettable: 0
   UnstackableAmount: 0
   UnresettableAmount: 0

--- a/Assets/ScriptableObjects/Cards/PrettyQuickAttack3.asset
+++ b/Assets/ScriptableObjects/Cards/PrettyQuickAttack3.asset
@@ -18,23 +18,23 @@ MonoBehaviour:
   DisplayName: Pretty Quick Attack
   CardDescription: Pepemon adds +2 to its Attack Power until end of turn.
   Rarity: 0
-  Type: 1
+  Type: 0
   CardEffectSprite: {fileID: 21300000, guid: d95fed4a4095d1f4b9306bb8735a0d1b, type: 3}
   AttackPower: 2
   DefensePower: 0
   effectOne:
-    basePower: 0
-    triggeredPower: 4
-    effectTo: 4
-    effectFor: 1
-    reqCode: 3
-  effectMany:
-    power: 1
-    numTurns: 0
-    effectTo: 4
+    basePower: 2
+    triggeredPower: 0
+    effectTo: 0
     effectFor: 0
-    reqCode: 8
-  Unstackable: 1
+    reqCode: 0
+  effectMany:
+    power: 0
+    numTurns: 0
+    effectTo: 0
+    effectFor: 0
+    reqCode: 0
+  Unstackable: 0
   Unresettable: 0
   UnstackableAmount: 0
   UnresettableAmount: 0

--- a/Assets/ScriptableObjects/Cards/PrettyQuickAttack3.asset.meta
+++ b/Assets/ScriptableObjects/Cards/PrettyQuickAttack3.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5d93dd2354bd67f4fac218cdef71c05c
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ScriptableObjects/Cards/QuickAttack.asset
+++ b/Assets/ScriptableObjects/Cards/QuickAttack.asset
@@ -18,23 +18,23 @@ MonoBehaviour:
   DisplayName: Quick Attack
   CardDescription: Pepemon adds +3 to its Attack Power until end of turn.
   Rarity: 0
-  Type: 1
+  Type: 0
   CardEffectSprite: {fileID: 21300000, guid: 04831dff486ee6544ba0a7d83363e3a5, type: 3}
   AttackPower: 3
   DefensePower: 0
   effectOne:
-    basePower: 1
+    basePower: 3
     triggeredPower: 0
-    effectTo: 5
+    effectTo: 0
     effectFor: 0
     reqCode: 0
   effectMany:
-    power: 3
+    power: 0
     numTurns: 0
     effectTo: 0
     effectFor: 0
-    reqCode: 4
-  Unstackable: 1
+    reqCode: 0
+  Unstackable: 0
   Unresettable: 0
   UnstackableAmount: 0
   UnresettableAmount: 0

--- a/Assets/ScriptableObjects/Cards/QuickAttack.asset
+++ b/Assets/ScriptableObjects/Cards/QuickAttack.asset
@@ -14,16 +14,27 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   UID: 14b52bdf-2a95-4c30-8347-b7305b49ea31
   Icon: {fileID: 0}
-  ID: 16
+  ID: 13
   DisplayName: Quick Attack
   CardDescription: Pepemon adds +3 to its Attack Power until end of turn.
   Rarity: 0
-  Type: 0
+  Type: 1
   CardEffectSprite: {fileID: 21300000, guid: 04831dff486ee6544ba0a7d83363e3a5, type: 3}
   AttackPower: 3
   DefensePower: 0
-  effectOnes: []
-  Unstackable: 0
+  effectOne:
+    basePower: 1
+    triggeredPower: 0
+    effectTo: 5
+    effectFor: 0
+    reqCode: 0
+  effectMany:
+    power: 3
+    numTurns: 0
+    effectTo: 0
+    effectFor: 0
+    reqCode: 4
+  Unstackable: 1
   Unresettable: 0
   UnstackableAmount: 0
   UnresettableAmount: 0

--- a/Assets/ScriptableObjects/Cards/QuickAttack.asset
+++ b/Assets/ScriptableObjects/Cards/QuickAttack.asset
@@ -22,6 +22,7 @@ MonoBehaviour:
   CardEffectSprite: {fileID: 21300000, guid: 04831dff486ee6544ba0a7d83363e3a5, type: 3}
   AttackPower: 3
   DefensePower: 0
+  effectOnes: []
   Unstackable: 0
   Unresettable: 0
   UnstackableAmount: 0

--- a/Assets/ScriptableObjects/Cards/QuickAttack2.asset
+++ b/Assets/ScriptableObjects/Cards/QuickAttack2.asset
@@ -10,32 +10,31 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 9e6e5e1c7c6330448a7000c2e43fca97, type: 3}
-  m_Name: Parry
+  m_Name: QuickAttack2
   m_EditorClassIdentifier: 
-  UID: 5e370533-afa6-425b-b31f-58e3797b4e66
+  UID: 14b52bdf-2a95-4c30-8347-b7305b49ea31
   Icon: {fileID: 0}
-  ID: 31
-  DisplayName: Perry
-  CardDescription: Pepemon adds +5 to its Defense Power for each +4 Defense card
-    used by the player during this turn
-  Rarity: 1
+  ID: 16
+  DisplayName: Quick Attack
+  CardDescription: Pepemon adds +3 to its Attack Power until end of turn.
+  Rarity: 0
   Type: 1
-  CardEffectSprite: {fileID: 21300000, guid: 43d8d0120a29e0546aa2d86d7a1a44ce, type: 3}
-  AttackPower: 0
-  DefensePower: 5
+  CardEffectSprite: {fileID: 21300000, guid: 04831dff486ee6544ba0a7d83363e3a5, type: 3}
+  AttackPower: 3
+  DefensePower: 0
   effectOne:
-    basePower: 2
-    triggeredPower: 0
-    effectTo: 1
+    basePower: 1
+    triggeredPower: 4
+    effectTo: 0
     effectFor: 1
-    reqCode: 3
+    reqCode: 10
   effectMany:
-    power: 4
-    numTurns: 1
-    effectTo: 2
-    effectFor: 1
+    power: 2
+    numTurns: 2
+    effectTo: 4
+    effectFor: 0
     reqCode: 0
-  Unstackable: 0
-  Unresettable: 0
+  Unstackable: 1
+  Unresettable: 1
   UnstackableAmount: 0
   UnresettableAmount: 0

--- a/Assets/ScriptableObjects/Cards/QuickAttack2.asset
+++ b/Assets/ScriptableObjects/Cards/QuickAttack2.asset
@@ -18,23 +18,23 @@ MonoBehaviour:
   DisplayName: Quick Attack
   CardDescription: Pepemon adds +3 to its Attack Power until end of turn.
   Rarity: 0
-  Type: 1
+  Type: 0
   CardEffectSprite: {fileID: 21300000, guid: 04831dff486ee6544ba0a7d83363e3a5, type: 3}
   AttackPower: 3
   DefensePower: 0
   effectOne:
-    basePower: 1
-    triggeredPower: 4
+    basePower: 3
+    triggeredPower: 0
     effectTo: 0
-    effectFor: 1
-    reqCode: 10
-  effectMany:
-    power: 2
-    numTurns: 2
-    effectTo: 4
     effectFor: 0
     reqCode: 0
-  Unstackable: 1
-  Unresettable: 1
+  effectMany:
+    power: 0
+    numTurns: 0
+    effectTo: 0
+    effectFor: 0
+    reqCode: 0
+  Unstackable: 0
+  Unresettable: 0
   UnstackableAmount: 0
   UnresettableAmount: 0

--- a/Assets/ScriptableObjects/Cards/QuickAttack2.asset.meta
+++ b/Assets/ScriptableObjects/Cards/QuickAttack2.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2241fa5e79c79ab4483f7a93ce304bc3
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ScriptableObjects/Cards/RiddleMeThis.asset
+++ b/Assets/ScriptableObjects/Cards/RiddleMeThis.asset
@@ -24,7 +24,19 @@ MonoBehaviour:
   CardEffectSprite: {fileID: 21300000, guid: 5b54c51e4ccec894a917dfccf61782ae, type: 3}
   AttackPower: 0
   DefensePower: 0
+  effectOne:
+    basePower: 4
+    triggeredPower: 2
+    effectTo: 3
+    effectFor: 1
+    reqCode: 6
+  effectMany:
+    power: 1
+    numTurns: 1
+    effectTo: 1
+    effectFor: 0
+    reqCode: 8
   Unstackable: 1
   Unresettable: 1
-  UnstackableAmount: 2
-  UnresettableAmount: 2
+  UnstackableAmount: 0
+  UnresettableAmount: 0

--- a/Assets/ScriptableObjects/Cards/RiddleMeThis.asset
+++ b/Assets/ScriptableObjects/Cards/RiddleMeThis.asset
@@ -25,17 +25,17 @@ MonoBehaviour:
   AttackPower: 0
   DefensePower: 0
   effectOne:
-    basePower: 4
-    triggeredPower: 2
-    effectTo: 3
+    basePower: 0
+    triggeredPower: 0
+    effectTo: 5
     effectFor: 1
-    reqCode: 6
+    reqCode: 0
   effectMany:
-    power: 1
-    numTurns: 1
-    effectTo: 1
-    effectFor: 0
-    reqCode: 8
+    power: -1
+    numTurns: 2
+    effectTo: 5
+    effectFor: 1
+    reqCode: 0
   Unstackable: 1
   Unresettable: 1
   UnstackableAmount: 0

--- a/Assets/ScriptableObjects/Cards/RugPull.asset
+++ b/Assets/ScriptableObjects/Cards/RugPull.asset
@@ -20,23 +20,23 @@ MonoBehaviour:
     the next 2 turns. (Unstackable 2, Unresettable 2) Effects do not stack with another
     card of the same name.
   Rarity: 2
-  Type: 1
+  Type: 3
   CardEffectSprite: {fileID: 21300000, guid: 831376e0e23717f41bbf534732f90155, type: 3}
   AttackPower: 0
   DefensePower: 0
   effectOne:
     basePower: 0
     triggeredPower: 0
-    effectTo: 1
-    effectFor: 0
-    reqCode: 7
-  effectMany:
-    power: 1
-    numTurns: 0
-    effectTo: 1
-    effectFor: 0
+    effectTo: 2
+    effectFor: 1
     reqCode: 0
-  Unstackable: 0
+  effectMany:
+    power: -5
+    numTurns: 2
+    effectTo: 2
+    effectFor: 1
+    reqCode: 0
+  Unstackable: 1
   Unresettable: 1
   UnstackableAmount: 2
   UnresettableAmount: 0

--- a/Assets/ScriptableObjects/Cards/RugPull.asset
+++ b/Assets/ScriptableObjects/Cards/RugPull.asset
@@ -20,11 +20,23 @@ MonoBehaviour:
     the next 2 turns. (Unstackable 2, Unresettable 2) Effects do not stack with another
     card of the same name.
   Rarity: 2
-  Type: 3
+  Type: 1
   CardEffectSprite: {fileID: 21300000, guid: 831376e0e23717f41bbf534732f90155, type: 3}
   AttackPower: 0
   DefensePower: 0
-  Unstackable: 1
+  effectOne:
+    basePower: 0
+    triggeredPower: 0
+    effectTo: 1
+    effectFor: 0
+    reqCode: 7
+  effectMany:
+    power: 1
+    numTurns: 0
+    effectTo: 1
+    effectFor: 0
+    reqCode: 0
+  Unstackable: 0
   Unresettable: 1
   UnstackableAmount: 2
-  UnresettableAmount: 2
+  UnresettableAmount: 0

--- a/Assets/ScriptableObjects/Cards/SecondWind.asset
+++ b/Assets/ScriptableObjects/Cards/SecondWind.asset
@@ -24,6 +24,18 @@ MonoBehaviour:
   CardEffectSprite: {fileID: 21300000, guid: 6d42d9345994778468bd479654ec271a, type: 3}
   AttackPower: 0
   DefensePower: 0
+  effectOne:
+    basePower: 3
+    triggeredPower: 2
+    effectTo: 5
+    effectFor: 1
+    reqCode: 9
+  effectMany:
+    power: 3
+    numTurns: 0
+    effectTo: 2
+    effectFor: 1
+    reqCode: 11
   Unstackable: 0
   Unresettable: 0
   UnstackableAmount: 0

--- a/Assets/ScriptableObjects/Cards/SecondWind.asset
+++ b/Assets/ScriptableObjects/Cards/SecondWind.asset
@@ -25,17 +25,17 @@ MonoBehaviour:
   AttackPower: 0
   DefensePower: 0
   effectOne:
-    basePower: 3
-    triggeredPower: 2
-    effectTo: 5
-    effectFor: 1
-    reqCode: 9
-  effectMany:
-    power: 3
-    numTurns: 0
-    effectTo: 2
+    basePower: 1
+    triggeredPower: 5
+    effectTo: 0
     effectFor: 1
     reqCode: 11
+  effectMany:
+    power: 0
+    numTurns: 0
+    effectTo: 0
+    effectFor: 0
+    reqCode: 0
   Unstackable: 0
   Unresettable: 0
   UnstackableAmount: 0

--- a/Assets/ScriptableObjects/Cards/Shield.asset
+++ b/Assets/ScriptableObjects/Cards/Shield.asset
@@ -22,6 +22,7 @@ MonoBehaviour:
   CardEffectSprite: {fileID: 21300000, guid: 7dc7f1d02ed27c24391aa58fe6fc1819, type: 3}
   AttackPower: 0
   DefensePower: 4
+  effectOnes: []
   Unstackable: 0
   Unresettable: 0
   UnstackableAmount: 0

--- a/Assets/ScriptableObjects/Cards/Shield.asset
+++ b/Assets/ScriptableObjects/Cards/Shield.asset
@@ -18,23 +18,23 @@ MonoBehaviour:
   DisplayName: Shield
   CardDescription: Pepemon adds +4 to its Defense Power until end of turn
   Rarity: 0
-  Type: 1
+  Type: 2
   CardEffectSprite: {fileID: 21300000, guid: 7dc7f1d02ed27c24391aa58fe6fc1819, type: 3}
   AttackPower: 0
   DefensePower: 4
   effectOne:
-    basePower: 1
-    triggeredPower: 2
-    effectTo: 0
-    effectFor: 1
-    reqCode: 4
+    basePower: 4
+    triggeredPower: 0
+    effectTo: 2
+    effectFor: 0
+    reqCode: 0
   effectMany:
-    power: 3
-    numTurns: 1
-    effectTo: 1
-    effectFor: 1
-    reqCode: 10
-  Unstackable: 1
-  Unresettable: 1
+    power: 0
+    numTurns: 0
+    effectTo: 0
+    effectFor: 0
+    reqCode: 0
+  Unstackable: 0
+  Unresettable: 0
   UnstackableAmount: 0
   UnresettableAmount: 0

--- a/Assets/ScriptableObjects/Cards/Shield.asset
+++ b/Assets/ScriptableObjects/Cards/Shield.asset
@@ -18,12 +18,23 @@ MonoBehaviour:
   DisplayName: Shield
   CardDescription: Pepemon adds +4 to its Defense Power until end of turn
   Rarity: 0
-  Type: 2
+  Type: 1
   CardEffectSprite: {fileID: 21300000, guid: 7dc7f1d02ed27c24391aa58fe6fc1819, type: 3}
   AttackPower: 0
   DefensePower: 4
-  effectOnes: []
-  Unstackable: 0
-  Unresettable: 0
+  effectOne:
+    basePower: 1
+    triggeredPower: 2
+    effectTo: 0
+    effectFor: 1
+    reqCode: 4
+  effectMany:
+    power: 3
+    numTurns: 1
+    effectTo: 1
+    effectFor: 1
+    reqCode: 10
+  Unstackable: 1
+  Unresettable: 1
   UnstackableAmount: 0
   UnresettableAmount: 0

--- a/Assets/ScriptableObjects/Cards/SuckerPunch.asset
+++ b/Assets/ScriptableObjects/Cards/SuckerPunch.asset
@@ -18,23 +18,23 @@ MonoBehaviour:
   DisplayName: Sucker Punch
   CardDescription: Opposing Pepemon gets -5 to its Defense Power until end of turn
   Rarity: 1
-  Type: 1
+  Type: 0
   CardEffectSprite: {fileID: 21300000, guid: 6f870ae8e22a4354faac7f7c9d229294, type: 3}
   AttackPower: 0
   DefensePower: 0
   effectOne:
-    basePower: 1
-    triggeredPower: 1
-    effectTo: 3
+    basePower: -5
+    triggeredPower: 0
+    effectTo: 2
     effectFor: 1
-    reqCode: 2
+    reqCode: 0
   effectMany:
     power: 0
     numTurns: 0
-    effectTo: 3
-    effectFor: 1
-    reqCode: 8
-  Unstackable: 1
-  Unresettable: 1
+    effectTo: 0
+    effectFor: 0
+    reqCode: 0
+  Unstackable: 0
+  Unresettable: 0
   UnstackableAmount: 0
   UnresettableAmount: 0

--- a/Assets/ScriptableObjects/Cards/SuckerPunch.asset
+++ b/Assets/ScriptableObjects/Cards/SuckerPunch.asset
@@ -18,11 +18,23 @@ MonoBehaviour:
   DisplayName: Sucker Punch
   CardDescription: Opposing Pepemon gets -5 to its Defense Power until end of turn
   Rarity: 1
-  Type: 0
+  Type: 1
   CardEffectSprite: {fileID: 21300000, guid: 6f870ae8e22a4354faac7f7c9d229294, type: 3}
   AttackPower: 0
   DefensePower: 0
-  Unstackable: 0
-  Unresettable: 0
+  effectOne:
+    basePower: 1
+    triggeredPower: 1
+    effectTo: 3
+    effectFor: 1
+    reqCode: 2
+  effectMany:
+    power: 0
+    numTurns: 0
+    effectTo: 3
+    effectFor: 1
+    reqCode: 8
+  Unstackable: 1
+  Unresettable: 1
   UnstackableAmount: 0
   UnresettableAmount: 0

--- a/Assets/ScriptableObjects/Cards/SuperFang.asset
+++ b/Assets/ScriptableObjects/Cards/SuperFang.asset
@@ -23,7 +23,19 @@ MonoBehaviour:
   CardEffectSprite: {fileID: 21300000, guid: 6cc6cd9aeea06ce48b3c50ff8107842c, type: 3}
   AttackPower: 7
   DefensePower: 0
+  effectOne:
+    basePower: 2
+    triggeredPower: 3
+    effectTo: 2
+    effectFor: 1
+    reqCode: 2
+  effectMany:
+    power: 1
+    numTurns: 0
+    effectTo: 5
+    effectFor: 1
+    reqCode: 9
   Unstackable: 0
-  Unresettable: 0
+  Unresettable: 1
   UnstackableAmount: 0
   UnresettableAmount: 0

--- a/Assets/ScriptableObjects/Cards/SuperFang.asset
+++ b/Assets/ScriptableObjects/Cards/SuperFang.asset
@@ -24,18 +24,18 @@ MonoBehaviour:
   AttackPower: 7
   DefensePower: 0
   effectOne:
-    basePower: 2
-    triggeredPower: 3
-    effectTo: 2
-    effectFor: 1
-    reqCode: 2
+    basePower: 7
+    triggeredPower: 7
+    effectTo: 0
+    effectFor: 0
+    reqCode: 3
   effectMany:
-    power: 1
+    power: 0
     numTurns: 0
-    effectTo: 5
-    effectFor: 1
-    reqCode: 9
+    effectTo: 0
+    effectFor: 0
+    reqCode: 0
   Unstackable: 0
-  Unresettable: 1
+  Unresettable: 0
   UnstackableAmount: 0
   UnresettableAmount: 0

--- a/Assets/ScriptableObjects/Cards/Taunt....asset
+++ b/Assets/ScriptableObjects/Cards/Taunt....asset
@@ -25,18 +25,18 @@ MonoBehaviour:
   AttackPower: 0
   DefensePower: 0
   effectOne:
-    basePower: 4
+    basePower: -3
     triggeredPower: 2
-    effectTo: 0
+    effectTo: 2
     effectFor: 1
-    reqCode: 6
+    reqCode: 0
   effectMany:
-    power: 4
-    numTurns: 1
-    effectTo: 3
-    effectFor: 0
-    reqCode: 10
-  Unstackable: 0
-  Unresettable: 0
+    power: -3
+    numTurns: 2
+    effectTo: 2
+    effectFor: 1
+    reqCode: 0
+  Unstackable: 1
+  Unresettable: 1
   UnstackableAmount: 2
   UnresettableAmount: 2

--- a/Assets/ScriptableObjects/Cards/Taunt....asset
+++ b/Assets/ScriptableObjects/Cards/Taunt....asset
@@ -24,7 +24,19 @@ MonoBehaviour:
   CardEffectSprite: {fileID: 21300000, guid: 20908c6287a4d764c9fa0771911fe834, type: 3}
   AttackPower: 0
   DefensePower: 0
-  Unstackable: 1
-  Unresettable: 1
+  effectOne:
+    basePower: 4
+    triggeredPower: 2
+    effectTo: 0
+    effectFor: 1
+    reqCode: 6
+  effectMany:
+    power: 4
+    numTurns: 1
+    effectTo: 3
+    effectFor: 0
+    reqCode: 10
+  Unstackable: 0
+  Unresettable: 0
   UnstackableAmount: 2
   UnresettableAmount: 2

--- a/Assets/ScriptableObjects/Cards/ThinkAndObserve.asset
+++ b/Assets/ScriptableObjects/Cards/ThinkAndObserve.asset
@@ -20,23 +20,23 @@ MonoBehaviour:
     Pepemon\u2019s Intelligence is 7 or more, add an additional +5 Defense Power
     to the Pepemon until end of turn."
   Rarity: 1
-  Type: 1
+  Type: 3
   CardEffectSprite: {fileID: 21300000, guid: 84c0e4a135fb5754c8fcf7e4ac48eda5, type: 3}
   AttackPower: 0
   DefensePower: 7
   effectOne:
-    basePower: 0
-    triggeredPower: 3
+    basePower: 2
+    triggeredPower: 7
     effectTo: 3
     effectFor: 0
     reqCode: 9
   effectMany:
     power: 0
     numTurns: 0
-    effectTo: 1
-    effectFor: 1
-    reqCode: 3
-  Unstackable: 1
-  Unresettable: 1
+    effectTo: 0
+    effectFor: 0
+    reqCode: 0
+  Unstackable: 0
+  Unresettable: 0
   UnstackableAmount: 0
   UnresettableAmount: 0

--- a/Assets/ScriptableObjects/Cards/ThinkAndObserve.asset
+++ b/Assets/ScriptableObjects/Cards/ThinkAndObserve.asset
@@ -20,11 +20,23 @@ MonoBehaviour:
     Pepemon\u2019s Intelligence is 7 or more, add an additional +5 Defense Power
     to the Pepemon until end of turn."
   Rarity: 1
-  Type: 3
+  Type: 1
   CardEffectSprite: {fileID: 21300000, guid: 84c0e4a135fb5754c8fcf7e4ac48eda5, type: 3}
   AttackPower: 0
   DefensePower: 7
-  Unstackable: 0
-  Unresettable: 0
+  effectOne:
+    basePower: 0
+    triggeredPower: 3
+    effectTo: 3
+    effectFor: 0
+    reqCode: 9
+  effectMany:
+    power: 0
+    numTurns: 0
+    effectTo: 1
+    effectFor: 1
+    reqCode: 3
+  Unstackable: 1
+  Unresettable: 1
   UnstackableAmount: 0
   UnresettableAmount: 0

--- a/Assets/ScriptableObjects/Cards/ThinkLessStrikeHarder.asset
+++ b/Assets/ScriptableObjects/Cards/ThinkLessStrikeHarder.asset
@@ -20,10 +20,22 @@ MonoBehaviour:
     of turn, the Pepemon receives an additional Attack Power equal to the total of
     all the offense cards used by its player this turn (excluding offense card bonuses)."
   Rarity: 2
-  Type: 3
+  Type: 1
   CardEffectSprite: {fileID: 21300000, guid: 799aa18debc0f7a44b9f1ac3e947f5a2, type: 3}
   AttackPower: 0
   DefensePower: 0
+  effectOne:
+    basePower: 4
+    triggeredPower: 0
+    effectTo: 5
+    effectFor: 0
+    reqCode: 1
+  effectMany:
+    power: 0
+    numTurns: 2
+    effectTo: 2
+    effectFor: 0
+    reqCode: 5
   Unstackable: 0
   Unresettable: 0
   UnstackableAmount: 0

--- a/Assets/ScriptableObjects/Cards/ThinkLessStrikeHarder.asset
+++ b/Assets/ScriptableObjects/Cards/ThinkLessStrikeHarder.asset
@@ -20,22 +20,22 @@ MonoBehaviour:
     of turn, the Pepemon receives an additional Attack Power equal to the total of
     all the offense cards used by its player this turn (excluding offense card bonuses)."
   Rarity: 2
-  Type: 1
+  Type: 3
   CardEffectSprite: {fileID: 21300000, guid: 799aa18debc0f7a44b9f1ac3e947f5a2, type: 3}
   AttackPower: 0
   DefensePower: 0
   effectOne:
-    basePower: 4
+    basePower: 0
     triggeredPower: 0
-    effectTo: 5
+    effectTo: 0
     effectFor: 0
     reqCode: 1
   effectMany:
     power: 0
-    numTurns: 2
-    effectTo: 2
+    numTurns: 0
+    effectTo: 0
     effectFor: 0
-    reqCode: 5
+    reqCode: 0
   Unstackable: 0
   Unresettable: 0
   UnstackableAmount: 0

--- a/Assets/ScriptableObjects/Cards/ThinkNowStrikeLater.asset
+++ b/Assets/ScriptableObjects/Cards/ThinkNowStrikeLater.asset
@@ -25,18 +25,18 @@ MonoBehaviour:
   AttackPower: 0
   DefensePower: 0
   effectOne:
-    basePower: 0
-    triggeredPower: 3
-    effectTo: 3
-    effectFor: 1
-    reqCode: 10
-  effectMany:
-    power: 3
-    numTurns: 0
-    effectTo: 3
+    basePower: 2
+    triggeredPower: 0
+    effectTo: 1
     effectFor: 0
-    reqCode: 3
-  Unstackable: 0
-  Unresettable: 0
+    reqCode: 0
+  effectMany:
+    power: 2
+    numTurns: 3
+    effectTo: 1
+    effectFor: 0
+    reqCode: 0
+  Unstackable: 1
+  Unresettable: 1
   UnstackableAmount: 3
   UnresettableAmount: 3

--- a/Assets/ScriptableObjects/Cards/ThinkNowStrikeLater.asset
+++ b/Assets/ScriptableObjects/Cards/ThinkNowStrikeLater.asset
@@ -20,11 +20,23 @@ MonoBehaviour:
     3 turns. (Unstackable 3, Unresettable 3) Effects do not stack or reset with another
     card of the same name.
   Rarity: 2
-  Type: 0
+  Type: 1
   CardEffectSprite: {fileID: 21300000, guid: 94ce8b49e4ae7a24caacd0f13ec23627, type: 3}
   AttackPower: 0
   DefensePower: 0
-  Unstackable: 1
-  Unresettable: 1
+  effectOne:
+    basePower: 0
+    triggeredPower: 3
+    effectTo: 3
+    effectFor: 1
+    reqCode: 10
+  effectMany:
+    power: 3
+    numTurns: 0
+    effectTo: 3
+    effectFor: 0
+    reqCode: 3
+  Unstackable: 0
+  Unresettable: 0
   UnstackableAmount: 3
   UnresettableAmount: 3

--- a/Assets/ScriptableObjects/Cards/UltimatePower.asset
+++ b/Assets/ScriptableObjects/Cards/UltimatePower.asset
@@ -23,6 +23,18 @@ MonoBehaviour:
   CardEffectSprite: {fileID: 21300000, guid: 618a0dc45e16a6a4b94a4ecc640978fb, type: 3}
   AttackPower: 0
   DefensePower: 0
+  effectOne:
+    basePower: 0
+    triggeredPower: 0
+    effectTo: 5
+    effectFor: 0
+    reqCode: 8
+  effectMany:
+    power: 1
+    numTurns: 0
+    effectTo: 4
+    effectFor: 1
+    reqCode: 7
   Unstackable: 0
   Unresettable: 0
   UnstackableAmount: 0

--- a/Assets/ScriptableObjects/Cards/UltimatePower.asset
+++ b/Assets/ScriptableObjects/Cards/UltimatePower.asset
@@ -26,16 +26,16 @@ MonoBehaviour:
   effectOne:
     basePower: 0
     triggeredPower: 0
-    effectTo: 5
+    effectTo: 1
     effectFor: 0
-    reqCode: 8
+    reqCode: 0
   effectMany:
-    power: 1
+    power: 0
     numTurns: 0
-    effectTo: 4
-    effectFor: 1
-    reqCode: 7
-  Unstackable: 0
+    effectTo: 1
+    effectFor: 0
+    reqCode: 0
+  Unstackable: 1
   Unresettable: 0
   UnstackableAmount: 0
   UnresettableAmount: 0

--- a/Assets/ScriptableObjects/Cards/WaterClone.asset
+++ b/Assets/ScriptableObjects/Cards/WaterClone.asset
@@ -20,11 +20,23 @@ MonoBehaviour:
     (Unstackable 2, Unresettable 2). Effects do not stack or reset with another card
     of the same name.
   Rarity: 1
-  Type: 2
+  Type: 1
   CardEffectSprite: {fileID: 21300000, guid: a0512ae0321622049a2bd2b270a85055, type: 3}
   AttackPower: 0
   DefensePower: 0
-  Unstackable: 0
+  effectOne:
+    basePower: 2
+    triggeredPower: 2
+    effectTo: 5
+    effectFor: 0
+    reqCode: 11
+  effectMany:
+    power: 1
+    numTurns: 0
+    effectTo: 0
+    effectFor: 1
+    reqCode: 5
+  Unstackable: 1
   Unresettable: 0
   UnstackableAmount: 0
   UnresettableAmount: 0

--- a/Assets/ScriptableObjects/Cards/WaterClone.asset
+++ b/Assets/ScriptableObjects/Cards/WaterClone.asset
@@ -20,23 +20,23 @@ MonoBehaviour:
     (Unstackable 2, Unresettable 2). Effects do not stack or reset with another card
     of the same name.
   Rarity: 1
-  Type: 1
+  Type: 2
   CardEffectSprite: {fileID: 21300000, guid: a0512ae0321622049a2bd2b270a85055, type: 3}
   AttackPower: 0
   DefensePower: 0
   effectOne:
-    basePower: 2
-    triggeredPower: 2
-    effectTo: 5
-    effectFor: 0
-    reqCode: 11
-  effectMany:
-    power: 1
-    numTurns: 0
+    basePower: 0
+    triggeredPower: 0
     effectTo: 0
+    effectFor: 0
+    reqCode: 0
+  effectMany:
+    power: -1
+    numTurns: 2
+    effectTo: 5
     effectFor: 1
-    reqCode: 5
+    reqCode: 0
   Unstackable: 1
-  Unresettable: 0
+  Unresettable: 1
   UnstackableAmount: 0
   UnresettableAmount: 0

--- a/Assets/ScriptableObjects/DataContainer.asset
+++ b/Assets/ScriptableObjects/DataContainer.asset
@@ -35,6 +35,7 @@ MonoBehaviour:
   - {fileID: 11400000, guid: e35e36a9896ecd54c809ac99b6fce6bb, type: 2}
   - {fileID: 11400000, guid: 41ebd60f34726ca49b82d68c9c5a45fa, type: 2}
   - {fileID: 11400000, guid: 2a87c5db3e39c9d4791e1f1bbc96d69d, type: 2}
+  - {fileID: 11400000, guid: 7e690757586d21141846a8be64cc64cc, type: 2}
   - {fileID: 11400000, guid: c07281458852cfb46b3aec0bb88de264, type: 2}
   - {fileID: 11400000, guid: 6d945cbc915d4ed4f912d25afa7b7522, type: 2}
   - {fileID: 11400000, guid: bd4a585b3bea78643a9e1cff4e5e8f75, type: 2}
@@ -51,7 +52,10 @@ MonoBehaviour:
   - {fileID: 11400000, guid: b9ec13903df51f04e9b7dabdc3516522, type: 2}
   - {fileID: 11400000, guid: 1f01f85b550ec4d47b66d60c00e1f8ce, type: 2}
   - {fileID: 11400000, guid: e131fce7b8e0e9745ae750d99a4bc3e2, type: 2}
+  - {fileID: 11400000, guid: a9ae4a580404c38418bb606dee25aca5, type: 2}
+  - {fileID: 11400000, guid: 5d93dd2354bd67f4fac218cdef71c05c, type: 2}
   - {fileID: 11400000, guid: 961f9e5e7685eb24dbfa3477ff829e28, type: 2}
+  - {fileID: 11400000, guid: 2241fa5e79c79ab4483f7a93ce304bc3, type: 2}
   - {fileID: 11400000, guid: aceb5bef68d82ee44b1c5ded8f0ac2cf, type: 2}
   - {fileID: 11400000, guid: 44d7d20ba6f414b46b2c34480d4bdb03, type: 2}
   - {fileID: 11400000, guid: 3414e6dc015582b4d94c72b5cd6f181e, type: 2}

--- a/Assets/ScriptableObjects/DataContainer.asset
+++ b/Assets/ScriptableObjects/DataContainer.asset
@@ -1,0 +1,66 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a2c44b48e521c2541889fa242f78de1c, type: 3}
+  m_Name: DataContainer
+  m_EditorClassIdentifier: Assembly-CSharp::PepemonContainer
+  Pepemons:
+  - {fileID: 11400000, guid: 688c66d2c258a734e913b87649e8511f, type: 2}
+  - {fileID: 11400000, guid: ddb8ec2fa924b684381d8bf4eb8d999b, type: 2}
+  - {fileID: 11400000, guid: f806b768bdbae3e4b953c457819b104d, type: 2}
+  - {fileID: 11400000, guid: ebf2eb4e75cd2fc41860cb891e6cbf2c, type: 2}
+  - {fileID: 11400000, guid: 0ad976d921ecb10458179cdf7af74d45, type: 2}
+  - {fileID: 11400000, guid: 0770c7f64a4d5cc459980bd1c25f35bf, type: 2}
+  - {fileID: 11400000, guid: 68517baabcd79414bbbcef049d5c8393, type: 2}
+  - {fileID: 11400000, guid: 05e2b65c718e1294881ec7c2fcadc414, type: 2}
+  - {fileID: 11400000, guid: 30cd4be5117b43546a6cb2d91165391f, type: 2}
+  - {fileID: 11400000, guid: ed441e7f604ed1242a3293d0786af48d, type: 2}
+  - {fileID: 11400000, guid: c6883baaf1d6dc64da74567d886f2a0f, type: 2}
+  - {fileID: 11400000, guid: 1e9fcdcb6b5e261429d84697d2a0e0fc, type: 2}
+  - {fileID: 11400000, guid: 6336132a4bf40534fabb8f8f19907f58, type: 2}
+  - {fileID: 11400000, guid: 7c7eb360152fbac4ba9415e12c03993d, type: 2}
+  - {fileID: 11400000, guid: b59c0e0fdaa2bd742b3850972a87c658, type: 2}
+  Cards:
+  - {fileID: 11400000, guid: a234538c2f067d74fbb9d4cb7b9db11d, type: 2}
+  - {fileID: 11400000, guid: 100407fe41bef734f87ddc46e60d41b5, type: 2}
+  - {fileID: 11400000, guid: 497705a2947800b498b2b380fd85107c, type: 2}
+  - {fileID: 11400000, guid: e35e36a9896ecd54c809ac99b6fce6bb, type: 2}
+  - {fileID: 11400000, guid: 41ebd60f34726ca49b82d68c9c5a45fa, type: 2}
+  - {fileID: 11400000, guid: 2a87c5db3e39c9d4791e1f1bbc96d69d, type: 2}
+  - {fileID: 11400000, guid: c07281458852cfb46b3aec0bb88de264, type: 2}
+  - {fileID: 11400000, guid: 6d945cbc915d4ed4f912d25afa7b7522, type: 2}
+  - {fileID: 11400000, guid: bd4a585b3bea78643a9e1cff4e5e8f75, type: 2}
+  - {fileID: 11400000, guid: ed62bab8acf2dcd4283c8f27d8931262, type: 2}
+  - {fileID: 11400000, guid: 75500cb15ae15004fa8c358356101060, type: 2}
+  - {fileID: 11400000, guid: 9189da6cff9f45642bad935b7215f625, type: 2}
+  - {fileID: 11400000, guid: cc6b65f822fe054439a9817e70d8b6e0, type: 2}
+  - {fileID: 11400000, guid: 37ec1b7b07b0db8498079aefb3f2e1d9, type: 2}
+  - {fileID: 11400000, guid: 022e407fb9dd4cb4ebf81dc981e06558, type: 2}
+  - {fileID: 11400000, guid: 427e21c6cd6ad9d47ab3243ebe1925ac, type: 2}
+  - {fileID: 11400000, guid: dde71bd895b0bfb469d2654c92ddb0d3, type: 2}
+  - {fileID: 11400000, guid: 441136123a29c20428f731aab60c77e7, type: 2}
+  - {fileID: 11400000, guid: 5d5e7028bc5814d43bb45e4b4f865f27, type: 2}
+  - {fileID: 11400000, guid: b9ec13903df51f04e9b7dabdc3516522, type: 2}
+  - {fileID: 11400000, guid: 1f01f85b550ec4d47b66d60c00e1f8ce, type: 2}
+  - {fileID: 11400000, guid: e131fce7b8e0e9745ae750d99a4bc3e2, type: 2}
+  - {fileID: 11400000, guid: 961f9e5e7685eb24dbfa3477ff829e28, type: 2}
+  - {fileID: 11400000, guid: aceb5bef68d82ee44b1c5ded8f0ac2cf, type: 2}
+  - {fileID: 11400000, guid: 44d7d20ba6f414b46b2c34480d4bdb03, type: 2}
+  - {fileID: 11400000, guid: 3414e6dc015582b4d94c72b5cd6f181e, type: 2}
+  - {fileID: 11400000, guid: 27a2866c0dc40084db13b9fca06c103f, type: 2}
+  - {fileID: 11400000, guid: ec3aa3d7ba3c84c41ad57a9c3ddda7d1, type: 2}
+  - {fileID: 11400000, guid: 9fe52ac3a64510f42836681d7ec96fcf, type: 2}
+  - {fileID: 11400000, guid: dd4064063a3c79241a442f7fae480338, type: 2}
+  - {fileID: 11400000, guid: 461c065e7ffd12f498e8fef4b9278214, type: 2}
+  - {fileID: 11400000, guid: 2d6e2112835917049b201ad205658598, type: 2}
+  - {fileID: 11400000, guid: 7bea708b595b8ce4999639fddae82372, type: 2}
+  - {fileID: 11400000, guid: 1e565ff87c5afc045b1450820a2a6b52, type: 2}
+  - {fileID: 11400000, guid: f4bc63fb98618fa4982bdcbc80bb1d26, type: 2}

--- a/Assets/ScriptableObjects/DataContainer.asset.meta
+++ b/Assets/ScriptableObjects/DataContainer.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d1fea7aba5f19cc45991de3bac22c468
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ScriptableObjects/Pepemons/Cosmony.asset
+++ b/Assets/ScriptableObjects/Pepemons/Cosmony.asset
@@ -19,9 +19,9 @@ MonoBehaviour:
   CardContentBackdrop: {fileID: 21300000, guid: c9d1d1b3352e4854cb2551f1aa2cbdfe, type: 3}
   CardContent: {fileID: 21300000, guid: ee60c3cf1e73fdf4d810c4e88a03bcac, type: 3}
   Level: 1
-  Type: 7
-  Weakness: 7
-  Resistence: 7
+  Type: 10
+  Weakness: 10
+  Resistence: 10
   Rarity: 0
   HealthPoints: 300
   Speed: 21

--- a/Assets/ScriptableObjects/Pepemons/Cosmony.asset
+++ b/Assets/ScriptableObjects/Pepemons/Cosmony.asset
@@ -23,7 +23,7 @@ MonoBehaviour:
   Weakness: 7
   Resistence: 7
   Rarity: 0
-  HealthPoints: 300
+  HealthPoints: 20
   Speed: 21
   Intelligence: 7
   Attack: 4

--- a/Assets/ScriptableObjects/Pepemons/Cosmony.asset
+++ b/Assets/ScriptableObjects/Pepemons/Cosmony.asset
@@ -23,7 +23,7 @@ MonoBehaviour:
   Weakness: 7
   Resistence: 7
   Rarity: 0
-  HealthPoints: 20
+  HealthPoints: 300
   Speed: 21
   Intelligence: 7
   Attack: 4

--- a/Assets/ScriptableObjects/Pepemons/Druky.asset
+++ b/Assets/ScriptableObjects/Pepemons/Druky.asset
@@ -19,9 +19,9 @@ MonoBehaviour:
   CardContentBackdrop: {fileID: 21300000, guid: 6c6139d92eb31b84e9633b365afe34a5, type: 3}
   CardContent: {fileID: 21300000, guid: f052fd0541801464ba8ee31176c61356, type: 3}
   Level: 1
-  Type: 2
+  Type: 4
   Weakness: 5
-  Resistence: 3
+  Resistence: 8
   Rarity: 0
   HealthPoints: 450
   Speed: 14

--- a/Assets/ScriptableObjects/Pepemons/Druky.asset
+++ b/Assets/ScriptableObjects/Pepemons/Druky.asset
@@ -23,7 +23,7 @@ MonoBehaviour:
   Weakness: 5
   Resistence: 3
   Rarity: 0
-  HealthPoints: 450
+  HealthPoints: 20
   Speed: 14
   Intelligence: 5
   Attack: 5

--- a/Assets/ScriptableObjects/Pepemons/Druky.asset
+++ b/Assets/ScriptableObjects/Pepemons/Druky.asset
@@ -23,7 +23,7 @@ MonoBehaviour:
   Weakness: 5
   Resistence: 3
   Rarity: 0
-  HealthPoints: 20
+  HealthPoints: 450
   Speed: 14
   Intelligence: 5
   Attack: 5

--- a/Assets/ScriptableObjects/Pepemons/Fafny.asset
+++ b/Assets/ScriptableObjects/Pepemons/Fafny.asset
@@ -20,8 +20,8 @@ MonoBehaviour:
   CardContent: {fileID: 21300000, guid: a8ecb66f6af6e6e4a80e33a5aff9e0f2, type: 3}
   Level: 1
   Type: 1
-  Weakness: 10
-  Resistence: 6
+  Weakness: 0
+  Resistence: 2
   Rarity: 0
   HealthPoints: 400
   Speed: 5

--- a/Assets/ScriptableObjects/Pepemons/Fafny.asset
+++ b/Assets/ScriptableObjects/Pepemons/Fafny.asset
@@ -23,7 +23,7 @@ MonoBehaviour:
   Weakness: 10
   Resistence: 6
   Rarity: 0
-  HealthPoints: 400
+  HealthPoints: 20
   Speed: 5
   Intelligence: 6
   Attack: 5

--- a/Assets/ScriptableObjects/Pepemons/Fafny.asset
+++ b/Assets/ScriptableObjects/Pepemons/Fafny.asset
@@ -23,7 +23,7 @@ MonoBehaviour:
   Weakness: 10
   Resistence: 6
   Rarity: 0
-  HealthPoints: 20
+  HealthPoints: 400
   Speed: 5
   Intelligence: 6
   Attack: 5

--- a/Assets/ScriptableObjects/Pepemons/Kirimu.asset
+++ b/Assets/ScriptableObjects/Pepemons/Kirimu.asset
@@ -19,8 +19,8 @@ MonoBehaviour:
   CardContentBackdrop: {fileID: 21300000, guid: d62edd61abd8e87419f6195bd152cd9a, type: 3}
   CardContent: {fileID: 21300000, guid: 886d29a165e9e1b41a95bdea603284fa, type: 3}
   Level: 1
-  Type: 5
-  Weakness: 6
+  Type: 4
+  Weakness: 5
   Resistence: 8
   Rarity: 0
   HealthPoints: 400

--- a/Assets/ScriptableObjects/Pepemons/Kirimu.asset
+++ b/Assets/ScriptableObjects/Pepemons/Kirimu.asset
@@ -23,10 +23,10 @@ MonoBehaviour:
   Weakness: 6
   Resistence: 8
   Rarity: 0
-  HealthPoints: 20
-  Speed: 5
+  HealthPoints: 400
+  Speed: 13
   Intelligence: 6
-  Attack: 25
-  Defense: 17
-  SAttack: 2
-  SDeffense: 5
+  Attack: 4
+  Defense: 10
+  SAttack: 17
+  SDeffense: 10

--- a/Assets/ScriptableObjects/Pepemons/Kirimu.asset
+++ b/Assets/ScriptableObjects/Pepemons/Kirimu.asset
@@ -23,7 +23,7 @@ MonoBehaviour:
   Weakness: 6
   Resistence: 8
   Rarity: 0
-  HealthPoints: 400
+  HealthPoints: 20
   Speed: 5
   Intelligence: 6
   Attack: 25

--- a/Assets/ScriptableObjects/Pepemons/Mandraky.asset
+++ b/Assets/ScriptableObjects/Pepemons/Mandraky.asset
@@ -23,7 +23,7 @@ MonoBehaviour:
   Weakness: 1
   Resistence: 10
   Rarity: 0
-  HealthPoints: 20
+  HealthPoints: 390
   Speed: 11
   Intelligence: 5
   Attack: 1

--- a/Assets/ScriptableObjects/Pepemons/Mandraky.asset
+++ b/Assets/ScriptableObjects/Pepemons/Mandraky.asset
@@ -23,7 +23,7 @@ MonoBehaviour:
   Weakness: 1
   Resistence: 10
   Rarity: 0
-  HealthPoints: 390
+  HealthPoints: 20
   Speed: 11
   Intelligence: 5
   Attack: 1

--- a/Assets/ScriptableObjects/Pepemons/Mandraky.asset
+++ b/Assets/ScriptableObjects/Pepemons/Mandraky.asset
@@ -19,9 +19,9 @@ MonoBehaviour:
   CardContentBackdrop: {fileID: 21300000, guid: 180ed81d3cf8d9c41ab9de24fefd6517, type: 3}
   CardContent: {fileID: 21300000, guid: a0461aa653fe6fe48936ca35b8048a3b, type: 3}
   Level: 1
-  Type: 6
-  Weakness: 1
-  Resistence: 10
+  Type: 2
+  Weakness: 3
+  Resistence: 0
   Rarity: 0
   HealthPoints: 390
   Speed: 11

--- a/Assets/ScriptableObjects/Pepemons/Marsher.asset
+++ b/Assets/ScriptableObjects/Pepemons/Marsher.asset
@@ -23,7 +23,7 @@ MonoBehaviour:
   Weakness: 9
   Resistence: 4
   Rarity: 0
-  HealthPoints: 20
+  HealthPoints: 400
   Speed: 10
   Intelligence: 10
   Attack: 10

--- a/Assets/ScriptableObjects/Pepemons/Marsher.asset
+++ b/Assets/ScriptableObjects/Pepemons/Marsher.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   UID: 8fae3bbb-b9fb-4188-89a0-b92227845397
   DisplayIcon: {fileID: 0}
-  ID: 28
+  ID: 
   DisplayName: Marsher
   CardContentBackdrop: {fileID: 21300000, guid: 4921eef12ba139b47a250e0ca4e9c717, type: 3}
   CardContent: {fileID: 21300000, guid: de86ecb120002b74ba73295bf659c4cf, type: 3}
@@ -23,7 +23,7 @@ MonoBehaviour:
   Weakness: 9
   Resistence: 4
   Rarity: 0
-  HealthPoints: 400
+  HealthPoints: 20
   Speed: 10
   Intelligence: 10
   Attack: 10

--- a/Assets/ScriptableObjects/Pepemons/Metaphy.asset
+++ b/Assets/ScriptableObjects/Pepemons/Metaphy.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   UID: 58715f61-1d13-456d-85e4-29667bec8256
   DisplayIcon: {fileID: 0}
-  ID: 20
+  ID: 
   DisplayName: Metaphy
   CardContentBackdrop: {fileID: 21300000, guid: 3e6344641535fdf4baee93b8722bbf68, type: 3}
   CardContent: {fileID: 21300000, guid: e996e435c12c8bf4cb69d1b30c2d1150, type: 3}
@@ -23,7 +23,7 @@ MonoBehaviour:
   Weakness: 9
   Resistence: 4
   Rarity: 0
-  HealthPoints: 400
+  HealthPoints: 20
   Speed: 10
   Intelligence: 10
   Attack: 10

--- a/Assets/ScriptableObjects/Pepemons/Metaphy.asset
+++ b/Assets/ScriptableObjects/Pepemons/Metaphy.asset
@@ -23,7 +23,7 @@ MonoBehaviour:
   Weakness: 9
   Resistence: 4
   Rarity: 0
-  HealthPoints: 20
+  HealthPoints: 400
   Speed: 10
   Intelligence: 10
   Attack: 10

--- a/Assets/ScriptableObjects/Pepemons/Moltry.asset
+++ b/Assets/ScriptableObjects/Pepemons/Moltry.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   UID: 5ddf710b-c5c2-42fa-986b-8b83a21d120f
   DisplayIcon: {fileID: 0}
-  ID: 12
+  ID: 
   DisplayName: Moltry
   CardContentBackdrop: {fileID: 21300000, guid: c00978c5966c33146836236f6b6e0552, type: 3}
   CardContent: {fileID: 21300000, guid: 7943a6531fbdcd245b71916878c56b28, type: 3}
@@ -23,7 +23,7 @@ MonoBehaviour:
   Weakness: 10
   Resistence: 6
   Rarity: 0
-  HealthPoints: 400
+  HealthPoints: 20
   Speed: 10
   Intelligence: 10
   Attack: 10

--- a/Assets/ScriptableObjects/Pepemons/Sairy.asset
+++ b/Assets/ScriptableObjects/Pepemons/Sairy.asset
@@ -23,10 +23,10 @@ MonoBehaviour:
   Weakness: 4
   Resistence: 5
   Rarity: 0
-  HealthPoints: 20
+  HealthPoints: 350
   Speed: 20
   Intelligence: 5
-  Attack: 50
+  Attack: 5
   Defense: 10
   SAttack: 15
   SDeffense: 10

--- a/Assets/ScriptableObjects/Pepemons/Sairy.asset
+++ b/Assets/ScriptableObjects/Pepemons/Sairy.asset
@@ -19,9 +19,9 @@ MonoBehaviour:
   CardContentBackdrop: {fileID: 21300000, guid: 94f7611efffce1e459212ad8f4615cd1, type: 3}
   CardContent: {fileID: 21300000, guid: 7fe94b6de461a0849969f346afbb450e, type: 3}
   Level: 1
-  Type: 3
-  Weakness: 4
-  Resistence: 5
+  Type: 5
+  Weakness: 7
+  Resistence: 1
   Rarity: 0
   HealthPoints: 350
   Speed: 20

--- a/Assets/ScriptableObjects/Pepemons/Sairy.asset
+++ b/Assets/ScriptableObjects/Pepemons/Sairy.asset
@@ -23,10 +23,10 @@ MonoBehaviour:
   Weakness: 4
   Resistence: 5
   Rarity: 0
-  HealthPoints: 350
+  HealthPoints: 20
   Speed: 20
   Intelligence: 5
-  Attack: 5
+  Attack: 50
   Defense: 10
   SAttack: 15
   SDeffense: 10

--- a/Assets/ScriptableObjects/Pepemons/Shapu.asset
+++ b/Assets/ScriptableObjects/Pepemons/Shapu.asset
@@ -19,9 +19,9 @@ MonoBehaviour:
   CardContentBackdrop: {fileID: 21300000, guid: 82b8fca82af9d094e8396042b68126b6, type: 3}
   CardContent: {fileID: 21300000, guid: e7b74aa810be28f45857af8177afed99, type: 3}
   Level: 1
-  Type: 5
-  Weakness: 6
-  Resistence: 8
+  Type: 9
+  Weakness: 10
+  Resistence: 10
   Rarity: 0
   HealthPoints: 400
   Speed: 5

--- a/Assets/ScriptableObjects/Pepemons/Shapu.asset
+++ b/Assets/ScriptableObjects/Pepemons/Shapu.asset
@@ -23,7 +23,7 @@ MonoBehaviour:
   Weakness: 6
   Resistence: 8
   Rarity: 0
-  HealthPoints: 20
+  HealthPoints: 400
   Speed: 5
   Intelligence: 6
   Attack: 25

--- a/Assets/ScriptableObjects/Pepemons/Shapu.asset
+++ b/Assets/ScriptableObjects/Pepemons/Shapu.asset
@@ -23,7 +23,7 @@ MonoBehaviour:
   Weakness: 6
   Resistence: 8
   Rarity: 0
-  HealthPoints: 400
+  HealthPoints: 20
   Speed: 5
   Intelligence: 6
   Attack: 25

--- a/Assets/ScriptableObjects/Pepemons/Toyol.asset
+++ b/Assets/ScriptableObjects/Pepemons/Toyol.asset
@@ -23,7 +23,7 @@ MonoBehaviour:
   Weakness: 6
   Resistence: 8
   Rarity: 0
-  HealthPoints: 20
+  HealthPoints: 400
   Speed: 10
   Intelligence: 10
   Attack: 10

--- a/Assets/ScriptableObjects/Pepemons/Toyol.asset
+++ b/Assets/ScriptableObjects/Pepemons/Toyol.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   UID: f368c14c-6ced-4f7d-8095-ceab4fbdba69
   DisplayIcon: {fileID: 0}
-  ID: 22
+  ID: 
   DisplayName: Toyol
   CardContentBackdrop: {fileID: 21300000, guid: 9bc02b89801ac6d4cbe4261117fb64d5, type: 3}
   CardContent: {fileID: 21300000, guid: 9b7399e4df6dd0c40b20781578d9e355, type: 3}
@@ -23,7 +23,7 @@ MonoBehaviour:
   Weakness: 6
   Resistence: 8
   Rarity: 0
-  HealthPoints: 400
+  HealthPoints: 20
   Speed: 10
   Intelligence: 10
   Attack: 10

--- a/Assets/ScriptableObjects/Pepemons/Unifairy.asset
+++ b/Assets/ScriptableObjects/Pepemons/Unifairy.asset
@@ -19,9 +19,9 @@ MonoBehaviour:
   CardContentBackdrop: {fileID: 21300000, guid: 0d3977d6fab14234586bf42865d660d7, type: 3}
   CardContent: {fileID: 21300000, guid: 5a1eaeae308d5b84ba85956663702fac, type: 3}
   Level: 1
-  Type: 9
-  Weakness: 8
-  Resistence: 9
+  Type: 8
+  Weakness: 1
+  Resistence: 6
   Rarity: 0
   HealthPoints: 320
   Speed: 18

--- a/Assets/ScriptableObjects/Pepemons/Unifairy.asset
+++ b/Assets/ScriptableObjects/Pepemons/Unifairy.asset
@@ -23,7 +23,7 @@ MonoBehaviour:
   Weakness: 8
   Resistence: 9
   Rarity: 0
-  HealthPoints: 320
+  HealthPoints: 20
   Speed: 18
   Intelligence: 5
   Attack: 5

--- a/Assets/ScriptableObjects/Pepemons/Unifairy.asset
+++ b/Assets/ScriptableObjects/Pepemons/Unifairy.asset
@@ -23,7 +23,7 @@ MonoBehaviour:
   Weakness: 8
   Resistence: 9
   Rarity: 0
-  HealthPoints: 20
+  HealthPoints: 320
   Speed: 18
   Intelligence: 5
   Attack: 5

--- a/Assets/ScriptableObjects/Pepemons/Venumu.asset
+++ b/Assets/ScriptableObjects/Pepemons/Venumu.asset
@@ -19,9 +19,9 @@ MonoBehaviour:
   CardContentBackdrop: {fileID: 21300000, guid: 0c2c8f3f511c1cf48a8753eb091880b5, type: 3}
   CardContent: {fileID: 21300000, guid: 0b1f88eca2da00b48bdec767687f1f2a, type: 3}
   Level: 1
-  Type: 4
-  Weakness: 9
-  Resistence: 6
+  Type: 6
+  Weakness: 7
+  Resistence: 5
   Rarity: 0
   HealthPoints: 400
   Speed: 5

--- a/Assets/ScriptableObjects/Pepemons/Venumu.asset
+++ b/Assets/ScriptableObjects/Pepemons/Venumu.asset
@@ -23,7 +23,7 @@ MonoBehaviour:
   Weakness: 9
   Resistence: 6
   Rarity: 0
-  HealthPoints: 400
+  HealthPoints: 20
   Speed: 0
   Intelligence: 0
   Attack: 0

--- a/Assets/ScriptableObjects/Pepemons/Venumu.asset
+++ b/Assets/ScriptableObjects/Pepemons/Venumu.asset
@@ -23,10 +23,10 @@ MonoBehaviour:
   Weakness: 9
   Resistence: 6
   Rarity: 0
-  HealthPoints: 20
-  Speed: 0
-  Intelligence: 0
-  Attack: 0
-  Defense: 0
-  SAttack: 0
-  SDeffense: 0
+  HealthPoints: 400
+  Speed: 5
+  Intelligence: 5
+  Attack: 5
+  Defense: 20
+  SAttack: 20
+  SDeffense: 5

--- a/Assets/ScriptableObjects/Pepemons/Witchenry.asset
+++ b/Assets/ScriptableObjects/Pepemons/Witchenry.asset
@@ -23,7 +23,7 @@ MonoBehaviour:
   Weakness: 9
   Resistence: 4
   Rarity: 0
-  HealthPoints: 290
+  HealthPoints: 20
   Speed: 14
   Intelligence: 7
   Attack: 11

--- a/Assets/ScriptableObjects/Pepemons/Witchenry.asset
+++ b/Assets/ScriptableObjects/Pepemons/Witchenry.asset
@@ -23,7 +23,7 @@ MonoBehaviour:
   Weakness: 9
   Resistence: 4
   Rarity: 0
-  HealthPoints: 20
+  HealthPoints: 290
   Speed: 14
   Intelligence: 7
   Attack: 11

--- a/Assets/ScriptableObjects/Pepemons/Witchenry.asset
+++ b/Assets/ScriptableObjects/Pepemons/Witchenry.asset
@@ -19,9 +19,9 @@ MonoBehaviour:
   CardContentBackdrop: {fileID: 21300000, guid: a01bf2faffe98d84d851ea5988c3293b, type: 3}
   CardContent: {fileID: 21300000, guid: 844ee28403394e34ca63016da96c7433, type: 3}
   Level: 1
-  Type: 8
-  Weakness: 9
-  Resistence: 4
+  Type: 7
+  Weakness: 6
+  Resistence: 7
   Rarity: 0
   HealthPoints: 290
   Speed: 14

--- a/Assets/ScriptableObjects/Pepemons/Zaptry.asset
+++ b/Assets/ScriptableObjects/Pepemons/Zaptry.asset
@@ -23,7 +23,7 @@ MonoBehaviour:
   Weakness: 5
   Resistence: 3
   Rarity: 0
-  HealthPoints: 400
+  HealthPoints: 20
   Speed: 10
   Intelligence: 10
   Attack: 10

--- a/Assets/ScriptableObjects/Pepemons/Zaptry.asset
+++ b/Assets/ScriptableObjects/Pepemons/Zaptry.asset
@@ -23,7 +23,7 @@ MonoBehaviour:
   Weakness: 5
   Resistence: 3
   Rarity: 0
-  HealthPoints: 20
+  HealthPoints: 400
   Speed: 10
   Intelligence: 10
   Attack: 10

--- a/Assets/Scripts/Contracts/ERC1155Common.cs
+++ b/Assets/Scripts/Contracts/ERC1155Common.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Nethereum.Contracts.Standards.ERC1155.ContractDefinition;
+using Nethereum.Unity.Rpc;
+
+public abstract class ERC1155Common
+{
+    /// <summary>
+    /// Tells whether or not a contract/wallet can transfer NFTs
+    /// </summary>
+    /// <param name="operatorAddress">Address of the contract/wallet</param>
+    /// <returns>result of IsApprovedForAll</returns>
+    protected static async Task<bool> GetApproval(string contractAddress, string operatorAddress)
+    {
+        var request = new QueryUnityRequest<IsApprovedForAllFunction, IsApprovedForAllOutputDTO>(
+           Web3Controller.instance.GetUnityRpcRequestClientFactory(),
+           Web3Controller.instance.SelectedAccountAddress);
+
+        var response = await request.QueryAsync(
+            new IsApprovedForAllFunction()
+            {
+                Account = Web3Controller.instance.SelectedAccountAddress,
+                Operator = operatorAddress
+            },
+            contractAddress);
+
+        return response.ReturnValue1;
+    }
+
+    /// <summary>
+    /// Approval is necessary to prevent this error in some cases: ERC1155#safeTransferFrom: INVALID_OPERATOR
+    /// </summary>
+    /// <param name="approved">Approval state to allow moving cards</param>
+    /// <param name="operatorAddress">Contract/wallet which will be given/revoked permission to transfer the NFTs</param>
+    /// <returns>Transaction hash</returns>
+    protected static async Task SetApproval(string contractAddress, bool approved, string operatorAddress)
+    {
+        var approvalRequest = Web3Controller.instance.GetContractTransactionUnityRequest();
+        await approvalRequest.SendTransactionAndWaitForReceiptAsync(
+            new SetApprovalForAllFunction()
+            {
+                Operator = operatorAddress,
+                Approved = approved
+            },
+            contractAddress);
+    }
+}
+

--- a/Assets/Scripts/Contracts/ERC1155Common.cs.meta
+++ b/Assets/Scripts/Contracts/ERC1155Common.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7472e552a046830449984ea166f3919a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Contracts/PepemonBattle.cs
+++ b/Assets/Scripts/Contracts/PepemonBattle.cs
@@ -8,12 +8,14 @@ using System.Threading.Tasks;
 using UnityEngine;
 using Nethereum.RPC.Eth.DTOs;
 using System.Linq;
+using System.Numerics;
+using static PepemonFactory;
 
 class PepemonBattle
 {
     private static string Address => Web3Controller.instance.GetChainConfig().pepemonBattleAddress;
 
-    public static async Task<ulong> GetBattleRNGSeed(ulong battleId)
+    public static async Task<BigInteger> GetBattleRNGSeed(ulong battleId)
     {
         var request = new QueryUnityRequest<BattleIdRNGSeedFunction, BattleIdRNGSeedOutputDTO>(
             Web3Controller.instance.GetUnityRpcRequestClientFactory(),
@@ -23,16 +25,43 @@ class PepemonBattle
             new BattleIdRNGSeedFunction { BattleId = battleId },
             Address);
 
-        return (ulong) response.Seed;
+        return response.Seed;
     }
 
-    public static async Task<uint> WaitForCreatedBattle(string player1Addr, BlockParameter from)
+    public static async Task<BattleCreatedEventData?> WaitForCreatedBattle(
+        string playerAddr1,
+        string playerAddr2,
+        BlockParameter from,
+        CancellationToken cancellationToken)
     {
         var eventLogs = await new BattleCreatedEventDTO()
             .GetEventABI()
-            .CreateFilterInput(Address, player1Addr, from, null)
-            .WaitForEventAsync<BattleCreatedEventDTO>();
+            .CreateFilterInput(Address, playerAddr1, playerAddr2, from, null)
+            .WaitForEventAsync<BattleCreatedEventDTO>(token: cancellationToken);
 
-        return (uint)eventLogs.Last().Event.BattleId;
+        var lastEvent = eventLogs.LastOrDefault()?.Event;
+        if (lastEvent == null)
+        {
+            return null;
+        }
+
+        return new BattleCreatedEventData()
+        {
+            BattleId = (ulong) lastEvent.BattleId,
+            Player1Addr = lastEvent.Player1Addr,
+            Player2Addr = lastEvent.Player2Addr,
+            Player1Deck = (ulong)lastEvent.Player1Deck,
+            Player2Deck = (ulong)lastEvent.Player2Deck,
+        };
+    }
+
+    [Serializable]
+    public struct BattleCreatedEventData
+    {
+        public ulong BattleId;
+        public string Player1Addr;
+        public string Player2Addr;
+        public ulong Player1Deck;
+        public ulong Player2Deck;
     }
 }

--- a/Assets/Scripts/Contracts/PepemonBattle.cs
+++ b/Assets/Scripts/Contracts/PepemonBattle.cs
@@ -9,7 +9,6 @@ using UnityEngine;
 using Nethereum.RPC.Eth.DTOs;
 using System.Linq;
 using System.Numerics;
-using static PepemonFactory;
 
 class PepemonBattle
 {

--- a/Assets/Scripts/Contracts/PepemonBattle.cs
+++ b/Assets/Scripts/Contracts/PepemonBattle.cs
@@ -1,16 +1,16 @@
 ﻿using Contracts.PepemonBattle.abi.ContractDefinition;
+using Nethereum.Contracts;
 using Nethereum.Unity.Rpc;
 using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using UnityEngine;
+using Nethereum.RPC.Eth.DTOs;
+using System.Linq;
 
 class PepemonBattle
 {
-    private const int WaitSleepDurationMs = 6500;
-    private const string AbiPath = "abi/PepemonBattle.abi";
-    private static readonly string abi = Resources.Load<TextAsset>(AbiPath).text;
     private static string Address => Web3Controller.instance.GetChainConfig().pepemonBattleAddress;
 
     public static async Task<ulong> GetBattleRNGSeed(ulong battleId)
@@ -24,5 +24,15 @@ class PepemonBattle
             Address);
 
         return (ulong) response.Seed;
+    }
+
+    public static async Task<uint> WaitForCreatedBattle(string player1Addr, BlockParameter from)
+    {
+        var eventLogs = await new BattleCreatedEventDTO()
+            .GetEventABI()
+            .CreateFilterInput(Address, player1Addr, from, null)
+            .WaitForEventAsync<BattleCreatedEventDTO>();
+
+        return (uint)eventLogs.Last().Event.BattleId;
     }
 }

--- a/Assets/Scripts/Contracts/PepemonBattle.cs
+++ b/Assets/Scripts/Contracts/PepemonBattle.cs
@@ -14,6 +14,12 @@ class PepemonBattle
 {
     private static string Address => Web3Controller.instance.GetChainConfig().pepemonBattleAddress;
 
+    /// <summary>
+    /// Retrieves the random seed generated during a new Battle.
+    /// The "ulong" type cannot be used as a return type because it cannot handle the generated seed's size
+    /// </summary>
+    /// <param name="battleId">ID of the battle</param>
+    /// <returns>The uint256 seed if the battle exists, 0 if the battle does not exists</returns>
     public static async Task<BigInteger> GetBattleRNGSeed(ulong battleId)
     {
         var request = new QueryUnityRequest<BattleIdRNGSeedFunction, BattleIdRNGSeedOutputDTO>(
@@ -27,6 +33,15 @@ class PepemonBattle
         return response.Seed;
     }
 
+    /// <summary>
+    /// Tries to get events based off two player's addresses, if the event is not found, keeps polling for events
+    /// and checking them until an event is found or cancellationToken is triggered
+    /// </summary>
+    /// <param name="playerAddr1">Address of the 1st player, ignored when Null</param>
+    /// <param name="playerAddr2">Address of the 2nd player, ignored when Null</param>
+    /// <param name="from">Filter from a specific block</param>
+    /// <param name="cancellationToken">Stops waiting for the event</param>
+    /// <returns>Data of the BattleCreated event if an event was found, null if cancellationToken was triggered</returns>
     public static async Task<BattleCreatedEventData?> WaitForCreatedBattle(
         string playerAddr1,
         string playerAddr2,

--- a/Assets/Scripts/Contracts/PepemonBattle/abi/ContractDefinition/PepemonBattle.abiDefinition.cs
+++ b/Assets/Scripts/Contracts/PepemonBattle/abi/ContractDefinition/PepemonBattle.abiDefinition.cs
@@ -148,8 +148,12 @@ namespace Contracts.PepemonBattle.abi.ContractDefinition
         public virtual string Player1Addr { get; set; }
         [Parameter("address", "player2Addr", 2, true )]
         public virtual string Player2Addr { get; set; }
-        [Parameter("uint256", "battleId", 3, false )]
+        [Parameter("uint256", "battleId", 3, false)]
         public virtual BigInteger BattleId { get; set; }
+        [Parameter("uint256", "p1DeckId", 4, false)]
+        public virtual BigInteger Player1Deck { get; set; }
+        [Parameter("uint256", "p2DeckId", 5, false)]
+        public virtual BigInteger Player2Deck { get; set; }
     }
 
 

--- a/Assets/Scripts/Contracts/PepemonBattle/abi/ContractDefinition/PepemonBattle.abiDefinition.cs
+++ b/Assets/Scripts/Contracts/PepemonBattle/abi/ContractDefinition/PepemonBattle.abiDefinition.cs
@@ -51,15 +51,6 @@ namespace Contracts.PepemonBattle.abi.ContractDefinition
         public virtual BigInteger BattleId { get; set; }
     }
 
-    public partial class BattlesFunction : BattlesFunctionBase { }
-
-    [Function("battles", typeof(BattlesOutputDTO))]
-    public class BattlesFunctionBase : FunctionMessage
-    {
-        [Parameter("uint256", "", 1)]
-        public virtual BigInteger ReturnValue1 { get; set; }
-    }
-
     public partial class CalSupportCardsInHandFunction : CalSupportCardsInHandFunctionBase { }
 
     [Function("calSupportCardsInHand", typeof(CalSupportCardsInHandOutputDTO))]
@@ -82,7 +73,7 @@ namespace Contracts.PepemonBattle.abi.ContractDefinition
 
     public partial class CreateBattleFunction : CreateBattleFunctionBase { }
 
-    [Function("createBattle")]
+    [Function("createBattle", typeof(CreateBattleOutputDTO))]
     public class CreateBattleFunctionBase : FunctionMessage
     {
         [Parameter("address", "p1Addr", 1)]
@@ -172,25 +163,6 @@ namespace Contracts.PepemonBattle.abi.ContractDefinition
         public virtual BigInteger Seed { get; set; }
     }
 
-    public partial class BattlesOutputDTO : BattlesOutputDTOBase { }
-
-    [FunctionOutput]
-    public class BattlesOutputDTOBase : IFunctionOutputDTO 
-    {
-        [Parameter("uint256", "battleId", 1)]
-        public virtual BigInteger BattleId { get; set; }
-        [Parameter("tuple", "player1", 2)]
-        public virtual Player Player1 { get; set; }
-        [Parameter("tuple", "player2", 3)]
-        public virtual Player Player2 { get; set; }
-        [Parameter("uint256", "currentTurn", 4)]
-        public virtual BigInteger CurrentTurn { get; set; }
-        [Parameter("uint8", "attacker", 5)]
-        public virtual byte Attacker { get; set; }
-        [Parameter("uint8", "turnHalves", 6)]
-        public virtual byte TurnHalves { get; set; }
-    }
-
     public partial class CalSupportCardsInHandOutputDTO : CalSupportCardsInHandOutputDTOBase { }
 
     [FunctionOutput]
@@ -213,7 +185,16 @@ namespace Contracts.PepemonBattle.abi.ContractDefinition
         public virtual string ReturnValue2 { get; set; }
     }
 
+    public partial class CreateBattleOutputDTO : CreateBattleOutputDTOBase { }
 
+    [FunctionOutput]
+    public class CreateBattleOutputDTOBase : IFunctionOutputDTO 
+    {
+        [Parameter("tuple", "", 1)]
+        public virtual Battle ReturnValue1 { get; set; }
+        [Parameter("uint256", "battleId", 2)]
+        public virtual BigInteger BattleId { get; set; }
+    }
 
     public partial class FightOutputDTO : FightOutputDTOBase { }
 

--- a/Assets/Scripts/Contracts/PepemonCardDeck.cs
+++ b/Assets/Scripts/Contracts/PepemonCardDeck.cs
@@ -103,6 +103,12 @@ public class PepemonCardDeck : ERC1155Common
         await SetApproval(Address, approved, operatorAddress);
     }
 
+    public static async Task MintCards()
+    {
+        var request = Web3Controller.instance.GetContractTransactionUnityRequest();
+        await request.SendTransactionAndWaitForReceiptAsync(new MintCardsFunction(), Address);
+    }
+
     public static async Task CreateDeck()
     {
         var request = Web3Controller.instance.GetContractTransactionUnityRequest();

--- a/Assets/Scripts/Contracts/PepemonCardDeck.cs
+++ b/Assets/Scripts/Contracts/PepemonCardDeck.cs
@@ -9,7 +9,7 @@ using Nethereum.Unity.Rpc;
 // Note: The generated code requires some small changes to work, like renaming the class pepemonCardDeck.abiDeployment to pepemonCardDeckAbiDeployment
 // as well as removing the .abiService.cs C# code, which is not used because relies on Web3 namespace, which is incompatible with WebGL.
 
-public class PepemonCardDeck
+public class PepemonCardDeck : ERC1155Common
 {
     /// <summary>
     /// PepemonCardDeck Contract Address
@@ -90,7 +90,18 @@ public class PepemonCardDeck
         return (ulong)response.ReturnValue1;
     }
 
+    public static async Task<bool> GetApprovalState(string operatorAddress)
+    {
+        return await GetApproval(Address, operatorAddress);
+    }
+
+
     // reference implementation for Write operations: https://github.com/Nethereum/Nethereum.Unity.Webgl/blob/main/Assets/MetamaskController.cs
+    
+    public static async Task SetApprovalState(bool approved, string operatorAddress)
+    {
+        await SetApproval(Address, approved, operatorAddress);
+    }
 
     public static async Task CreateDeck()
     {

--- a/Assets/Scripts/Contracts/PepemonCardDeck.cs
+++ b/Assets/Scripts/Contracts/PepemonCardDeck.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Collections.Specialized;
 using System.Linq;
 using System.Threading.Tasks;
 using Contracts.PepemonCardDeck.abi.ContractDefinition;
@@ -29,7 +30,7 @@ public class PepemonCardDeck : ERC1155Common
         return (ulong)response.ReturnValue1;
     }
 
-    public static async Task<Dictionary<ulong, int>> GetAllSupportCards(ulong deckId)
+    public static async Task<IDictionary<ulong, int>> GetAllSupportCards(ulong deckId)
     {
         var request = new QueryUnityRequest<GetAllSupportCardsInDeckFunction, GetAllSupportCardsInDeckOutputDTO>(
             Web3Controller.instance.GetUnityRpcRequestClientFactory(),
@@ -39,7 +40,7 @@ public class PepemonCardDeck : ERC1155Common
             new GetAllSupportCardsInDeckFunction { DeckId = deckId },
             Address);
 
-        var result = new Dictionary<ulong, int>();
+        var result = new OrderedDictionary<ulong, int>();
         foreach (var card in response.SupportCards)
         {
             result[card] = result.ContainsKey(card) ? result[card] + 1 : 1;

--- a/Assets/Scripts/Contracts/PepemonCardDeck/abi/ContractDefinition/PepemonCardDeck.abiDefinition.cs
+++ b/Assets/Scripts/Contracts/PepemonCardDeck/abi/ContractDefinition/PepemonCardDeck.abiDefinition.cs
@@ -187,6 +187,14 @@ namespace Contracts.PepemonCardDeck.abi.ContractDefinition
         public virtual string Operator { get; set; }
     }
 
+    public partial class MintCardsFunction : MintCardsFunctionBase { }
+
+    [Function("mintCards")]
+    public class MintCardsFunctionBase : FunctionMessage
+    {
+
+    }
+
     public partial class NameFunction : NameFunctionBase { }
 
     [Function("name", "string")]
@@ -349,6 +357,15 @@ namespace Contracts.PepemonCardDeck.abi.ContractDefinition
     {
         [Parameter("uint256", "_minSupportCards", 1)]
         public virtual BigInteger MinSupportCards { get; set; }
+    }
+
+    public partial class SetMintingRandomCardsFunction : SetMintingRandomCardsFunctionBase { }
+
+    [Function("setMintingRandomCards")]
+    public class SetMintingRandomCardsFunctionBase : FunctionMessage
+    {
+        [Parameter("uint256", "maxCard", 1)]
+        public virtual BigInteger MaxCard { get; set; }
     }
 
     public partial class SetSupportCardAddressFunction : SetSupportCardAddressFunctionBase { }

--- a/Assets/Scripts/Contracts/PepemonFactory.cs
+++ b/Assets/Scripts/Contracts/PepemonFactory.cs
@@ -8,7 +8,7 @@ using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using UnityEngine;
 
-class PepemonFactory
+class PepemonFactory : ERC1155Common
 {
     /// <summary>
     /// PepemonFactory address (Support cards, Battle cards)
@@ -124,19 +124,7 @@ class PepemonFactory
     /// <returns>result of IsApprovedForAll</returns>
     public static async Task<bool> GetApprovalState(string operatorAddress)
     {
-        var request = new QueryUnityRequest<IsApprovedForAllFunction, IsApprovedForAllOutputDTO>(
-           Web3Controller.instance.GetUnityRpcRequestClientFactory(),
-           Web3Controller.instance.SelectedAccountAddress);
-
-        var response = await request.QueryAsync(
-            new IsApprovedForAllFunction()
-            {
-                Owner = Web3Controller.instance.SelectedAccountAddress,
-                Operator = operatorAddress
-            },
-            Address);
-
-        return response.IsOperator;
+        return await GetApproval(Address, operatorAddress);
     }
 
     /// <summary>
@@ -147,14 +135,7 @@ class PepemonFactory
     /// <returns>Transaction hash</returns>
     public static async Task SetApprovalState(bool approved, string operatorAddress)
     {
-        var approvalRequest = Web3Controller.instance.GetContractTransactionUnityRequest();
-        await approvalRequest.SendTransactionAndWaitForReceiptAsync(
-            new SetApprovalForAllFunction()
-            {
-                Operator = operatorAddress,
-                Approved = approved
-            },
-            Address);
+        await SetApproval(Address, approved, operatorAddress);
     }
 
     [Serializable]

--- a/Assets/Scripts/Contracts/PepemonMatchmaker.cs
+++ b/Assets/Scripts/Contracts/PepemonMatchmaker.cs
@@ -1,0 +1,35 @@
+using Contracts.PepemonMatchmaker.abi.ContractDefinition;
+using Nethereum.Unity.Rpc;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Numerics;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using UnityEngine;
+
+public class PepemonMatchmaker
+{
+    public enum PepemonLeagues
+    {
+        Rice = 0,
+        PepeKarp,
+        Chad
+    }
+
+    /// <summary>
+    /// PepemonMatchmaker address
+    /// </summary>
+    private static string[] Addresses => Web3Controller.instance.GetChainConfig().pepemonMatchmakerAddresses;
+
+    public static async Task EnterBattle(PepemonLeagues league, ulong deckId)
+    {
+        var request = Web3Controller.instance.GetContractTransactionUnityRequest();
+        await request.SignAndSendTransactionAsync(
+            new EnterFunction()
+            {
+                DeckId = deckId,
+            },
+            Addresses[(int)league]);
+    }
+}

--- a/Assets/Scripts/Contracts/PepemonMatchmaker.cs
+++ b/Assets/Scripts/Contracts/PepemonMatchmaker.cs
@@ -24,6 +24,42 @@ public class PepemonMatchmaker
     /// </summary>
     private static string[] Addresses => Web3Controller.instance.GetChainConfig().pepemonMatchmakerAddresses;
 
+
+    public static async Task<string> GetDeckOwner(PepemonLeagues league, ulong deckId)
+    {
+        var request = new QueryUnityRequest<DeckOwnerFunction, DeckOwnerOutputDTO>(
+        Web3Controller.instance.GetUnityRpcRequestClientFactory(),
+        Web3Controller.instance.SelectedAccountAddress);
+
+        var response = await request.QueryAsync(
+            new DeckOwnerFunction { DeckId = deckId },
+            Addresses[(int)league]);
+
+        return response.ReturnValue1;
+    }
+
+    public static async Task<uint> GetBattleFinishedEvents(
+        PepemonLeagues league,
+        string playerAddress,
+        bool asWinner,
+        BlockParameter from,
+        BlockParameter to)
+    {
+        var eventLogs = await new BattleFinishedEventDTO()
+            .GetEventABI()
+            .CreateFilterInput(
+                Addresses[(int)league],
+                asWinner ? playerAddress : null,       // address winner
+                asWinner ? null : playerAddress,       // address loser
+                from,
+                to
+             )
+            .GetEventsAsync<BattleFinishedEventDTO>();
+
+        return (uint)eventLogs.Last().Event.BattleId;
+    }
+
+
     public static async Task Enter(PepemonLeagues league, ulong deckId)
     {
         var request = Web3Controller.instance.GetContractTransactionUnityRequest();
@@ -44,26 +80,5 @@ public class PepemonMatchmaker
                 DeckId = deckId,
             },
             Addresses[(int)league]);
-    }
-
-    public static async Task<uint> GetBattleFinishedEvents(
-        PepemonLeagues league,
-        string playerAddress,
-        bool asWinner,
-        BlockParameter 
-        from,BlockParameter to)
-    {
-        var eventLogs = await new BattleFinishedEventDTO()
-            .GetEventABI()
-            .CreateFilterInput(
-                Addresses[(int)league], 
-                asWinner ? playerAddress : null,       // address winner
-                asWinner ? null : playerAddress,       // address loser
-                from,
-                to
-             )
-            .GetEventsAsync<BattleFinishedEventDTO>();
-
-        return (uint)eventLogs.Last().Event.BattleId;
     }
 }

--- a/Assets/Scripts/Contracts/PepemonMatchmaker.cs.meta
+++ b/Assets/Scripts/Contracts/PepemonMatchmaker.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f89e1d1ac7017264ba6013803b1bcc51
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Contracts/PepemonMatchmaker.meta
+++ b/Assets/Scripts/Contracts/PepemonMatchmaker.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 238f7c73142772a4e94d6775e7c7db7f
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Contracts/PepemonMatchmaker/abi.meta
+++ b/Assets/Scripts/Contracts/PepemonMatchmaker/abi.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8c98e90be2017a944878ca5127b56bf1
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Contracts/PepemonMatchmaker/abi/ContractDefinition.meta
+++ b/Assets/Scripts/Contracts/PepemonMatchmaker/abi/ContractDefinition.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: bd0d68b0354148c4fbd33958da6f208f
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Contracts/PepemonMatchmaker/abi/ContractDefinition/PepemonMatchmakerDefinition.cs
+++ b/Assets/Scripts/Contracts/PepemonMatchmaker/abi/ContractDefinition/PepemonMatchmakerDefinition.cs
@@ -1,0 +1,327 @@
+using System;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+using System.Numerics;
+using Nethereum.Hex.HexTypes;
+using Nethereum.ABI.FunctionEncoding.Attributes;
+using Nethereum.Web3;
+using Nethereum.RPC.Eth.DTOs;
+using Nethereum.Contracts.CQS;
+using Nethereum.Contracts;
+using System.Threading;
+
+namespace Contracts.PepemonMatchmaker.abi.ContractDefinition
+{
+
+
+    public partial class PepemonMatchmakerAbiDeployment : PepemonMatchmakerAbiDeploymentBase
+    {
+        public PepemonMatchmakerAbiDeployment() : base(BYTECODE) { }
+        public PepemonMatchmakerAbiDeployment(string byteCode) : base(byteCode) { }
+    }
+
+    public class PepemonMatchmakerAbiDeploymentBase : ContractDeploymentMessage
+    {
+        public static string BYTECODE = "";
+        public PepemonMatchmakerAbiDeploymentBase() : base(BYTECODE) { }
+        public PepemonMatchmakerAbiDeploymentBase(string byteCode) : base(byteCode) { }
+        [Parameter("uint256", "defaultRanking", 1)]
+        public virtual BigInteger DefaultRanking { get; set; }
+        [Parameter("address", "battleAddress", 2)]
+        public virtual string BattleAddress { get; set; }
+        [Parameter("address", "deckAddress", 3)]
+        public virtual string DeckAddress { get; set; }
+        [Parameter("address", "rewardPoolAddress", 4)]
+        public virtual string RewardPoolAddress { get; set; }
+    }
+
+    public partial class DeckOwnerFunction : DeckOwnerFunctionBase { }
+
+    [Function("deckOwner", "address")]
+    public class DeckOwnerFunctionBase : FunctionMessage
+    {
+        [Parameter("uint256", "", 1)]
+        public virtual BigInteger ReturnValue1 { get; set; }
+    }
+
+    public partial class EnterFunction : EnterFunctionBase { }
+
+    [Function("enter")]
+    public class EnterFunctionBase : FunctionMessage
+    {
+        [Parameter("uint256", "deckId", 1)]
+        public virtual BigInteger DeckId { get; set; }
+    }
+
+    public partial class ExitFunction : ExitFunctionBase { }
+
+    [Function("exit")]
+    public class ExitFunctionBase : FunctionMessage
+    {
+        [Parameter("uint256", "deckId", 1)]
+        public virtual BigInteger DeckId { get; set; }
+    }
+
+    public partial class GetEloRatingChangeFunction : GetEloRatingChangeFunctionBase { }
+
+    [Function("getEloRatingChange", "uint256")]
+    public class GetEloRatingChangeFunctionBase : FunctionMessage
+    {
+        [Parameter("uint256", "winnerRating", 1)]
+        public virtual BigInteger WinnerRating { get; set; }
+        [Parameter("uint256", "loserRating", 2)]
+        public virtual BigInteger LoserRating { get; set; }
+    }
+
+    public partial class GetWaitingCountFunction : GetWaitingCountFunctionBase { }
+
+    [Function("getWaitingCount", "uint256")]
+    public class GetWaitingCountFunctionBase : FunctionMessage
+    {
+
+    }
+
+    public partial class OnERC1155BatchReceivedFunction : OnERC1155BatchReceivedFunctionBase { }
+
+    [Function("onERC1155BatchReceived", "bytes4")]
+    public class OnERC1155BatchReceivedFunctionBase : FunctionMessage
+    {
+        [Parameter("address", "", 1)]
+        public virtual string ReturnValue1 { get; set; }
+        [Parameter("address", "", 2)]
+        public virtual string ReturnValue2 { get; set; }
+        [Parameter("uint256[]", "", 3)]
+        public virtual List<BigInteger> ReturnValue3 { get; set; }
+        [Parameter("uint256[]", "", 4)]
+        public virtual List<BigInteger> ReturnValue4 { get; set; }
+        [Parameter("bytes", "", 5)]
+        public virtual byte[] ReturnValue5 { get; set; }
+    }
+
+    public partial class OnERC1155ReceivedFunction : OnERC1155ReceivedFunctionBase { }
+
+    [Function("onERC1155Received", "bytes4")]
+    public class OnERC1155ReceivedFunctionBase : FunctionMessage
+    {
+        [Parameter("address", "", 1)]
+        public virtual string ReturnValue1 { get; set; }
+        [Parameter("address", "", 2)]
+        public virtual string ReturnValue2 { get; set; }
+        [Parameter("uint256", "", 3)]
+        public virtual BigInteger ReturnValue3 { get; set; }
+        [Parameter("uint256", "", 4)]
+        public virtual BigInteger ReturnValue4 { get; set; }
+        [Parameter("bytes", "", 5)]
+        public virtual byte[] ReturnValue5 { get; set; }
+    }
+
+    public partial class OwnerFunction : OwnerFunctionBase { }
+
+    [Function("owner", "address")]
+    public class OwnerFunctionBase : FunctionMessage
+    {
+
+    }
+
+    public partial class PlayerRankingFunction : PlayerRankingFunctionBase { }
+
+    [Function("playerRanking", "uint256")]
+    public class PlayerRankingFunctionBase : FunctionMessage
+    {
+        [Parameter("address", "", 1)]
+        public virtual string ReturnValue1 { get; set; }
+    }
+
+    public partial class RenounceOwnershipFunction : RenounceOwnershipFunctionBase { }
+
+    [Function("renounceOwnership")]
+    public class RenounceOwnershipFunctionBase : FunctionMessage
+    {
+
+    }
+
+    public partial class SetBattleContractAddressFunction : SetBattleContractAddressFunctionBase { }
+
+    [Function("setBattleContractAddress")]
+    public class SetBattleContractAddressFunctionBase : FunctionMessage
+    {
+        [Parameter("address", "battleContractAddress", 1)]
+        public virtual string BattleContractAddress { get; set; }
+    }
+
+    public partial class SetDeckContractAddressFunction : SetDeckContractAddressFunctionBase { }
+
+    [Function("setDeckContractAddress")]
+    public class SetDeckContractAddressFunctionBase : FunctionMessage
+    {
+        [Parameter("address", "deckContractAddress", 1)]
+        public virtual string DeckContractAddress { get; set; }
+    }
+
+    public partial class SetKFactorFunction : SetKFactorFunctionBase { }
+
+    [Function("setKFactor")]
+    public class SetKFactorFunctionBase : FunctionMessage
+    {
+        [Parameter("uint256", "kFactor", 1)]
+        public virtual BigInteger KFactor { get; set; }
+    }
+
+    public partial class SetMatchRangeFunction : SetMatchRangeFunctionBase { }
+
+    [Function("setMatchRange")]
+    public class SetMatchRangeFunctionBase : FunctionMessage
+    {
+        [Parameter("uint256", "matchRange", 1)]
+        public virtual BigInteger MatchRange { get; set; }
+        [Parameter("uint256", "matchRangePerMinute", 2)]
+        public virtual BigInteger MatchRangePerMinute { get; set; }
+    }
+
+    public partial class SetRewardPoolAddressFunction : SetRewardPoolAddressFunctionBase { }
+
+    [Function("setRewardPoolAddress")]
+    public class SetRewardPoolAddressFunctionBase : FunctionMessage
+    {
+        [Parameter("address", "rewardPoolAddress", 1)]
+        public virtual string RewardPoolAddress { get; set; }
+    }
+
+    public partial class SupportsInterfaceFunction : SupportsInterfaceFunctionBase { }
+
+    [Function("supportsInterface", "bool")]
+    public class SupportsInterfaceFunctionBase : FunctionMessage
+    {
+        [Parameter("bytes4", "interfaceId", 1)]
+        public virtual byte[] InterfaceId { get; set; }
+    }
+
+    public partial class TransferOwnershipFunction : TransferOwnershipFunctionBase { }
+
+    [Function("transferOwnership")]
+    public class TransferOwnershipFunctionBase : FunctionMessage
+    {
+        [Parameter("address", "newOwner", 1)]
+        public virtual string NewOwner { get; set; }
+    }
+
+    public partial class WaitingDecksFunction : WaitingDecksFunctionBase { }
+
+    [Function("waitingDecks", typeof(WaitingDecksOutputDTO))]
+    public class WaitingDecksFunctionBase : FunctionMessage
+    {
+        [Parameter("uint256", "", 1)]
+        public virtual BigInteger ReturnValue1 { get; set; }
+    }
+
+    public partial class BattleFinishedEventDTO : BattleFinishedEventDTOBase { }
+
+    [Event("BattleFinished")]
+    public class BattleFinishedEventDTOBase : IEventDTO
+    {
+        [Parameter("address", "winner", 1, true )]
+        public virtual string Winner { get; set; }
+        [Parameter("address", "loser", 2, true )]
+        public virtual string Loser { get; set; }
+        [Parameter("uint256", "battleId", 3, false )]
+        public virtual BigInteger BattleId { get; set; }
+    }
+
+    public partial class OwnershipTransferredEventDTO : OwnershipTransferredEventDTOBase { }
+
+    [Event("OwnershipTransferred")]
+    public class OwnershipTransferredEventDTOBase : IEventDTO
+    {
+        [Parameter("address", "previousOwner", 1, true )]
+        public virtual string PreviousOwner { get; set; }
+        [Parameter("address", "newOwner", 2, true )]
+        public virtual string NewOwner { get; set; }
+    }
+
+    public partial class DeckOwnerOutputDTO : DeckOwnerOutputDTOBase { }
+
+    [FunctionOutput]
+    public class DeckOwnerOutputDTOBase : IFunctionOutputDTO 
+    {
+        [Parameter("address", "", 1)]
+        public virtual string ReturnValue1 { get; set; }
+    }
+
+
+
+
+
+    public partial class GetEloRatingChangeOutputDTO : GetEloRatingChangeOutputDTOBase { }
+
+    [FunctionOutput]
+    public class GetEloRatingChangeOutputDTOBase : IFunctionOutputDTO 
+    {
+        [Parameter("uint256", "", 1)]
+        public virtual BigInteger ReturnValue1 { get; set; }
+    }
+
+    public partial class GetWaitingCountOutputDTO : GetWaitingCountOutputDTOBase { }
+
+    [FunctionOutput]
+    public class GetWaitingCountOutputDTOBase : IFunctionOutputDTO 
+    {
+        [Parameter("uint256", "", 1)]
+        public virtual BigInteger ReturnValue1 { get; set; }
+    }
+
+
+
+
+
+    public partial class OwnerOutputDTO : OwnerOutputDTOBase { }
+
+    [FunctionOutput]
+    public class OwnerOutputDTOBase : IFunctionOutputDTO 
+    {
+        [Parameter("address", "", 1)]
+        public virtual string ReturnValue1 { get; set; }
+    }
+
+    public partial class PlayerRankingOutputDTO : PlayerRankingOutputDTOBase { }
+
+    [FunctionOutput]
+    public class PlayerRankingOutputDTOBase : IFunctionOutputDTO 
+    {
+        [Parameter("uint256", "", 1)]
+        public virtual BigInteger ReturnValue1 { get; set; }
+    }
+
+
+
+
+
+
+
+
+
+
+
+
+
+    public partial class SupportsInterfaceOutputDTO : SupportsInterfaceOutputDTOBase { }
+
+    [FunctionOutput]
+    public class SupportsInterfaceOutputDTOBase : IFunctionOutputDTO 
+    {
+        [Parameter("bool", "", 1)]
+        public virtual bool ReturnValue1 { get; set; }
+    }
+
+
+
+    public partial class WaitingDecksOutputDTO : WaitingDecksOutputDTOBase { }
+
+    [FunctionOutput]
+    public class WaitingDecksOutputDTOBase : IFunctionOutputDTO 
+    {
+        [Parameter("uint256", "deckId", 1)]
+        public virtual BigInteger DeckId { get; set; }
+        [Parameter("uint256", "enterTimestamp", 2)]
+        public virtual BigInteger EnterTimestamp { get; set; }
+    }
+}

--- a/Assets/Scripts/Contracts/PepemonMatchmaker/abi/ContractDefinition/PepemonMatchmakerDefinition.cs
+++ b/Assets/Scripts/Contracts/PepemonMatchmaker/abi/ContractDefinition/PepemonMatchmakerDefinition.cs
@@ -41,7 +41,7 @@ namespace Contracts.PepemonMatchmaker.abi.ContractDefinition
     public class DeckOwnerFunctionBase : FunctionMessage
     {
         [Parameter("uint256", "", 1)]
-        public virtual BigInteger ReturnValue1 { get; set; }
+        public virtual BigInteger DeckId { get; set; }
     }
 
     public partial class EnterFunction : EnterFunctionBase { }

--- a/Assets/Scripts/Contracts/PepemonMatchmaker/abi/ContractDefinition/PepemonMatchmakerDefinition.cs.meta
+++ b/Assets/Scripts/Contracts/PepemonMatchmaker/abi/ContractDefinition/PepemonMatchmakerDefinition.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4ba71097f5538e142b3e9a289f11974b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Controllers/BattlePrepController.cs
+++ b/Assets/Scripts/Controllers/BattlePrepController.cs
@@ -12,7 +12,6 @@ using UnityEngine.UI;
 
 public class BattlePrepController : MonoBehaviour
 {
-
     [TitleGroup("Component References"), SerializeField] GameObject _searchForOpponentButton;
     [TitleGroup("Component References"), SerializeField] GameObject _exitButton;
     [TitleGroup("Component References"), SerializeField] GameObject _deckList;
@@ -149,8 +148,7 @@ public class BattlePrepController : MonoBehaviour
         }
     }
 
-    [Serializable]
-    public struct BattleData
+    public class BattleData
     {
         public BigInteger battleRngSeed;
         public ulong player1BattleCard;
@@ -158,5 +156,4 @@ public class BattlePrepController : MonoBehaviour
         public Dictionary<ulong, int> player1SupportCards;
         public Dictionary<ulong, int> player2SupportCards;
     }
-
 }

--- a/Assets/Scripts/Controllers/BattlePrepController.cs
+++ b/Assets/Scripts/Controllers/BattlePrepController.cs
@@ -21,11 +21,10 @@ public class BattlePrepController : MonoBehaviour
     [ReadOnly] private CancellationTokenSource _cancellationTokenSource;
 
     // used on GameController on the battle scene
-    public static BattleData battleData { get; private set; }
+    public static BattleData battleData { get; private set; } = new BattleData();
 
     void Start()
     {
-        battleData ??= new BattleData();
         _searchForOpponentButton.GetComponent<Button>().onClick.AddListener(OnSearchForOpponentButtonClick);
         _exitButton.GetComponent<Button>().onClick.AddListener(onExitButtonClick);
         _deckList.GetComponent<DeckListLoader>().onSelectDeck.AddListener(OnDeckSelected);

--- a/Assets/Scripts/Controllers/BattlePrepController.cs
+++ b/Assets/Scripts/Controllers/BattlePrepController.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Nethereum.Hex.HexTypes;
+using Nethereum.RPC.Eth.DTOs;
+using Sirenix.OdinInspector;
+using UnityEngine;
+using UnityEngine.UI;
+
+public class BattlePrepController : MonoBehaviour
+{
+    [TitleGroup("Component References"), SerializeField] GameObject _searchForOpponentButton;
+    [TitleGroup("Component References"), SerializeField] GameObject _deckList;
+
+    [ReadOnly] private PepemonMatchmaker.PepemonLeagues selectedLeague;
+    [ReadOnly] private ulong selectedDeck;
+
+    void Start()
+    {
+        _searchForOpponentButton.GetComponent<Button>().onClick.AddListener(OnSearchForOpponentButtonClick);
+        _deckList.GetComponent<DeckListLoader>().onSelectDeck.AddListener(OnDeckSelected);
+    }
+
+    // set by LeagueSelection buttons
+    public void SetLeague(int league)
+    {
+        selectedLeague = (PepemonMatchmaker.PepemonLeagues)league;
+    }
+
+    public void OnDeckSelected(ulong deckId)
+    {
+        selectedDeck = deckId;
+    }
+
+    private async void OnSearchForOpponentButtonClick()
+    {
+        // SetApprovalForAll for CardDeck
+        await EnsureDeckTransferApproved();
+
+        var blockNumber = await new BlockParameter().RequestLatestBlockNumber();
+        
+        // filter events starting from this block
+        var nextBlock = new BlockParameter((blockNumber.BlockNumber.ToUlong() + 1).ToHexBigInteger());
+
+        FindObjectOfType<MainMenuController>().ShowScreen(7);
+
+        Debug.Log("battle start");
+        await PepemonMatchmaker.EnterBattle(selectedLeague, selectedDeck);
+
+        Debug.Log("waiting events");
+        var battleId = await PepemonBattle.WaitForCreatedBattle(
+            Web3Controller.instance.SelectedAccountAddress,
+            nextBlock);
+        Debug.Log("battlid:" + battleId);
+
+        Debug.Log("battle ended");
+    }
+
+    private async Task EnsureDeckTransferApproved()
+    {
+        var matchmakerAddress = Web3Controller.instance.GetChainConfig().pepemonMatchmakerAddresses[(int)selectedLeague];
+        // necessary to avoid "ERC1155#safeTransferFrom: INVALID_OPERATOR"
+        // TODO: place this in an "approve" button
+        var approvalOk = await PepemonCardDeck.GetApprovalState(matchmakerAddress);
+        if (!approvalOk)
+        {
+            try
+            {
+                await PepemonCardDeck.SetApprovalState(true, matchmakerAddress);
+                approvalOk = await PepemonCardDeck.GetApprovalState(matchmakerAddress);
+            }
+            catch (Exception ex)
+            {
+                Debug.LogWarning("SetApprovedForAll failed: " + ex.Message);
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Controllers/BattlePrepController.cs
+++ b/Assets/Scripts/Controllers/BattlePrepController.cs
@@ -176,7 +176,7 @@ public class BattlePrepController : MonoBehaviour
         public BigInteger battleRngSeed { get; set; }
         public ulong player1BattleCard { get; set; }
         public ulong player2BattleCard { get; set; }
-        public Dictionary<ulong, int> player1SupportCards { get; set; }
-        public Dictionary<ulong, int> player2SupportCards { get; set; }
+        public IDictionary<ulong, int> player1SupportCards { get; set; }
+        public IDictionary<ulong, int> player2SupportCards { get; set; }
     }
 }

--- a/Assets/Scripts/Controllers/BattlePrepController.cs
+++ b/Assets/Scripts/Controllers/BattlePrepController.cs
@@ -103,6 +103,10 @@ public class BattlePrepController : MonoBehaviour
         // initiate the battle immediatelly if the player initiated the battle
         if (battleEvent != null)
         {
+            // prevent player from clicking on the Exit button if BattleCreated event was captured
+            _exitButton.GetComponent<Button>().interactable = false;
+            
+            // proceed into the next scene
             await InitBattleScene((PepemonBattle.BattleCreatedEventData) battleEvent);
         }
     }

--- a/Assets/Scripts/Controllers/BattlePrepController.cs
+++ b/Assets/Scripts/Controllers/BattlePrepController.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Numerics;
+using System.Threading;
 using System.Threading.Tasks;
 using Nethereum.Hex.HexTypes;
 using Nethereum.RPC.Eth.DTOs;
@@ -10,15 +12,21 @@ using UnityEngine.UI;
 
 public class BattlePrepController : MonoBehaviour
 {
+
     [TitleGroup("Component References"), SerializeField] GameObject _searchForOpponentButton;
     [TitleGroup("Component References"), SerializeField] GameObject _exitButton;
     [TitleGroup("Component References"), SerializeField] GameObject _deckList;
 
     [ReadOnly] private PepemonMatchmaker.PepemonLeagues selectedLeague;
     [ReadOnly] private ulong selectedDeck;
+    [ReadOnly] private CancellationTokenSource _cancellationTokenSource;
+
+    // loaded on GameController
+    public static BattleData battleData;
 
     void Start()
     {
+        battleData ??= new BattleData();
         _searchForOpponentButton.GetComponent<Button>().onClick.AddListener(OnSearchForOpponentButtonClick);
         _exitButton.GetComponent<Button>().onClick.AddListener(onExitButtonClick);
         _deckList.GetComponent<DeckListLoader>().onSelectDeck.AddListener(OnDeckSelected);
@@ -41,28 +49,74 @@ public class BattlePrepController : MonoBehaviour
         await EnsureDeckTransferApproved();
 
         var blockNumber = await new BlockParameter().RequestLatestBlockNumber();
-        
-        // filter events starting from this block
+
+        // filter events starting from the next block, to avoid possibly getting the last battle of the player
         var nextBlock = new BlockParameter((blockNumber.BlockNumber.ToUlong() + 1).ToHexBigInteger());
 
         FindObjectOfType<MainMenuController>().ShowScreen(7);
 
+
         Debug.Log("Looking for battle");
         await PepemonMatchmaker.Enter(selectedLeague, selectedDeck);
+
+        var deckOwner = await PepemonMatchmaker.GetDeckOwner(selectedLeague, selectedDeck);
+
+        string player1addr = Web3Controller.instance.SelectedAccountAddress, 
+               player2addr = null;
+
+        // If the player is in the waitlist, then its because a battle has Not started yet, the current player's address will
+        // be in the second parameter of the BattleCreated event in this case.
+        // However if the battle has started, the player's address will be in the first parameter of the BattleCreated event
+        if (deckOwner == player1addr)
+        {
+            player2addr = player1addr;
+            player1addr = null;
+        }
 
         _exitButton.GetComponent<Button>().interactable = true;
 
         Debug.Log("Waiting for CreatedBattle events");
-        var battleId = await PepemonBattle.WaitForCreatedBattle(
-            Web3Controller.instance.SelectedAccountAddress,
-            nextBlock);
-        Debug.Log("Received battle event. BattlId:" + battleId);
+
+        _cancellationTokenSource = new CancellationTokenSource();
+        var battleEvent = await PepemonBattle.WaitForCreatedBattle(
+                player1addr,
+                player2addr,
+                nextBlock, 
+                _cancellationTokenSource.Token);
+
+        if (battleEvent != null)
+        {
+            Debug.Log("Received battle event. BattleId: " + battleEvent?.BattleId);
+
+            await PrepareBattleScene((PepemonBattle.BattleCreatedEventData) battleEvent);
+        }
+    }
+
+    private async Task PrepareBattleScene(PepemonBattle.BattleCreatedEventData battleEventData)
+    {
+        Debug.Log("Loading battle data..");
+
+        var reqBattleRngSeed = PepemonBattle.GetBattleRNGSeed(battleEventData.BattleId);
+        var reqPlayer1BattleCard = PepemonCardDeck.GetBattleCard(battleEventData.Player1Deck);
+        var reqPlayer2BattleCard = PepemonCardDeck.GetBattleCard(battleEventData.Player2Deck);
+        var reqPlayer1SupportCards = PepemonCardDeck.GetAllSupportCards(battleEventData.Player1Deck);
+        var reqPlayer2SupportCards = PepemonCardDeck.GetAllSupportCards(battleEventData.Player2Deck);
+        await Task.WhenAll(reqBattleRngSeed, reqPlayer1BattleCard, reqPlayer2BattleCard, reqPlayer1SupportCards, reqPlayer2SupportCards);
+
+        Debug.Log("Battle data loaded");
+        
+        battleData.battleRngSeed = reqBattleRngSeed.Result;
+        battleData.player1BattleCard = reqPlayer1BattleCard.Result;
+        battleData.player2BattleCard = reqPlayer2BattleCard.Result;
+        battleData.player1SupportCards = reqPlayer1SupportCards.Result;
+        battleData.player2SupportCards = reqPlayer2SupportCards.Result;
     }
 
     private async void onExitButtonClick()
     {
         try
         {
+            _cancellationTokenSource.Cancel();
             _exitButton.GetComponent<Button>().interactable = false;
             Debug.Log("Trying to exit matchmaking");
             await PepemonMatchmaker.Exit(selectedLeague, selectedDeck);
@@ -94,4 +148,15 @@ public class BattlePrepController : MonoBehaviour
             }
         }
     }
+
+    [Serializable]
+    public struct BattleData
+    {
+        public BigInteger battleRngSeed;
+        public ulong player1BattleCard;
+        public ulong player2BattleCard;
+        public Dictionary<ulong, int> player1SupportCards;
+        public Dictionary<ulong, int> player2SupportCards;
+    }
+
 }

--- a/Assets/Scripts/Controllers/BattlePrepController.cs.meta
+++ b/Assets/Scripts/Controllers/BattlePrepController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b1b06452cb3f9f34abff20f82c8066c0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Controllers/DeckController.cs
+++ b/Assets/Scripts/Controllers/DeckController.cs
@@ -19,6 +19,7 @@ public class DeckController : MonoBehaviour
     [BoxGroup("Deck Components"), SerializeField] private TMP_Text _winCount;
     [BoxGroup("Deck Components"), SerializeField] private TMP_Text _lossCount;
 
+    public UnityEvent onSelectButtonClicked;
     public UnityEvent onEditButtonClicked;
 
     /// <summary>
@@ -52,6 +53,7 @@ public class DeckController : MonoBehaviour
     void OnSelectClicked()
     {
         GetComponent<SelectionItem>().ToggleSelected();
+        onSelectButtonClicked?.Invoke();
     }
 
     public async Task LoadDeckInfo(ulong deckId)

--- a/Assets/Scripts/Controllers/GameController.cs
+++ b/Assets/Scripts/Controllers/GameController.cs
@@ -11,6 +11,10 @@ using Nethereum.RLP;
 // Manages the automation of the game. Each round is composed of two hands being played (offense and defense)
 public class GameController : MonoBehaviour
 {
+    private const int PLAYER1_SEED = 69;
+    private const int PLAYER2_SEED = 420;
+    private const int TIEBREAK_SEED = 69420;
+
     //Attacker can either be PLAYER_ONE or PLAYER_TWO
     private enum Attacker
     {
@@ -98,8 +102,8 @@ public class GameController : MonoBehaviour
         _player2.Initialise(2);
         _uiController.InitialiseGame(_player1, _player2);
 
-        _player1.GetAndShuffelDeck(69, _roundNumber, battleSeed);
-        _player2.GetAndShuffelDeck(420, _roundNumber, battleSeed);
+        _player1.GetAndShuffelDeck(PLAYER1_SEED, _roundNumber, battleSeed);
+        _player2.GetAndShuffelDeck(PLAYER2_SEED, _roundNumber, battleSeed);
     }
 
     IEnumerator LoopGame()
@@ -139,13 +143,13 @@ public class GameController : MonoBehaviour
             //Need to refresh decks
 
             // Shuffle player1 support cards
-            _player1.GetAndShuffelDeck(69, _roundNumber, battleSeed);
+            _player1.GetAndShuffelDeck(PLAYER1_SEED, _roundNumber, battleSeed);
 
             //Reset played card count
             _player1.PlayedCardCount = 0;
 
             // Shuffle player2 support cards
-            _player2.GetAndShuffelDeck(420, _roundNumber, battleSeed);
+            _player2.GetAndShuffelDeck(PLAYER2_SEED, _roundNumber, battleSeed);
 
             //Reset played card count
             _player2.PlayedCardCount = 0;
@@ -275,7 +279,7 @@ public class GameController : MonoBehaviour
                     // calculate random seed like in solidity
                     var abiEncode = new ABIEncode();
                     var rand = abiEncode.GetSha3ABIEncodedPacked(
-                        new ABIValue("uint256", 69420),
+                        new ABIValue("uint256", TIEBREAK_SEED),
                         new ABIValue("uint256", _roundNumber),
                         new ABIValue("uint256", battleSeed)).ToBigIntegerFromRLPDecoded();
 

--- a/Assets/Scripts/Controllers/GameController.cs
+++ b/Assets/Scripts/Controllers/GameController.cs
@@ -482,12 +482,12 @@ public class GameController : MonoBehaviour
 
                 // Calc effects of EffectOne
                 
-                    (bool isTriggered, int multiplier) = CheckReqCode(atkPlayer, defPlayer, effectOne.reqCode, true);
+                (bool isTriggered, int num) = CheckReqCode(atkPlayer, defPlayer, effectOne.reqCode, true);
                     if (isTriggered)
                     {
-                        if (multiplier > 1)
+                    if (num > 0)
                         {
-                            defPlayer.CurrentPepemonStats.def += effectOne.triggeredPower * multiplier;
+                        defPlayer.CurrentPepemonStats.def += effectOne.triggeredPower * num;
                         }
                         else
                         {

--- a/Assets/Scripts/Controllers/GameController.cs
+++ b/Assets/Scripts/Controllers/GameController.cs
@@ -463,7 +463,6 @@ public class GameController : MonoBehaviour
                     }
                 
                 }
-            }
             else if (card.Type == PlayCardType.SpecialDefense)
             {
                 // Card type is STRONG DEFENSE

--- a/Assets/Scripts/Controllers/GameController.cs
+++ b/Assets/Scripts/Controllers/GameController.cs
@@ -75,13 +75,13 @@ public class GameController : MonoBehaviour
     // Each player shuffles their deck and draws cards equal to pepemon intelligence 
     void InitFirstRound()
     {
-        _roundNumber = 1;
+        _roundNumber = 0;
         _player1.Initialise(1);
         _player2.Initialise(2);
         _uiController.InitialiseGame(_player1, _player2);
 
-        _player1.GetAndShuffelDeck(2); // todo: pass in seed from client connection index
-        _player2.GetAndShuffelDeck(1); // todo: pass in seed from client connection index
+        _player1.GetAndShuffelDeck(69, _roundNumber, BattlePrepController.battleData.battleRngSeed);
+        _player2.GetAndShuffelDeck(420, _roundNumber, BattlePrepController.battleData.battleRngSeed);
 
         // Calculate first attacker
         _attackFirstIndex = _player1.PlayerPepemon.Speed > _player2.PlayerPepemon.Speed ? 1 : 2;
@@ -117,8 +117,8 @@ public class GameController : MonoBehaviour
         // Check if we passed 5 and if so reshuffel decks
         if (_roundNumber >= 5)
         {
-            _player1.GetAndShuffelDeck(2 + _roundNumber); // todo: pass in seed from client connection index
-            _player2.GetAndShuffelDeck(1 + _roundNumber); // todo: pass in seed from client connection index
+            _player1.GetAndShuffelDeck(69, _roundNumber, BattlePrepController.battleData.battleRngSeed);
+            _player2.GetAndShuffelDeck(420, _roundNumber, BattlePrepController.battleData.battleRngSeed);
         }
 
         Debug.Log("<b>DRAWING HANDS</b>");
@@ -188,6 +188,8 @@ public class GameController : MonoBehaviour
 
                     if (_player1.CurrentHP <= 0) Winner(_player2);
                 }
+                Debug.Log("goForBattle _player1.CurrentHP=" + _player1.CurrentHP);
+                Debug.Log("goForBattle _player2.CurrentHP=" + _player2.CurrentHP);
 
                 Debug.Log("waiting 2f");
                 yield return new WaitForSeconds(1f);

--- a/Assets/Scripts/Controllers/GameController.cs
+++ b/Assets/Scripts/Controllers/GameController.cs
@@ -70,13 +70,13 @@ public class GameController : MonoBehaviour
         BattlePrepController.battleData.battleRngSeed = BigInteger.Parse(
             "68188038832262297884772284640717549873770515354422947402145954532168121309549");
         BattlePrepController.battleData.player1BattleCard = 1;
-        BattlePrepController.battleData.player1SupportCards = new Dictionary<ulong, int>()
+        BattlePrepController.battleData.player1SupportCards = new OrderedDictionary<ulong, int>()
         {
             [12] = 1,
             [28] = 2
         };
         BattlePrepController.battleData.player2BattleCard = 2;
-        BattlePrepController.battleData.player2SupportCards = new Dictionary<ulong, int>()
+        BattlePrepController.battleData.player2SupportCards = new OrderedDictionary<ulong, int>()
         {
             [12] = 1,
             [29] = 1,

--- a/Assets/Scripts/Controllers/GameController.cs
+++ b/Assets/Scripts/Controllers/GameController.cs
@@ -21,8 +21,12 @@ public class GameController : MonoBehaviour
     [BoxGroup("Pepemon Controller")] public PepemonCardController player1Controller;
     [BoxGroup("Pepemon Controller")] public PepemonCardController player2Controller;
 
+    [TitleGroup("Scriptable objects list"), SerializeField] DataContainer CardsScriptableObjsData;
+
     private void Start()
     {
+        PrepareDecksBeforeBattle();
+
         player1Controller.PopulateCard(_player1.PlayerPepemon);
         player2Controller.PopulateCard(_player2.PlayerPepemon);
 
@@ -30,6 +34,25 @@ public class GameController : MonoBehaviour
         {
             InitFirstRound();
             StartCoroutine(LoopGame());
+        }
+    }
+
+    private void PrepareDecksBeforeBattle()
+    {
+        // might be null if ran from unity editor
+        if (BattlePrepController.battleData != null)
+        {
+            _player1.SetPlayerDeck(
+                pepemon: CardsScriptableObjsData.GetPepemonById(BattlePrepController.battleData.player1BattleCard.ToString()),
+                supportCards: CardsScriptableObjsData.GetAllCardsByIds(BattlePrepController.battleData.player1SupportCards));
+
+            _player2.SetPlayerDeck(
+                pepemon: CardsScriptableObjsData.GetPepemonById(BattlePrepController.battleData.player2BattleCard.ToString()),
+                supportCards: CardsScriptableObjsData.GetAllCardsByIds(BattlePrepController.battleData.player2SupportCards));
+        }
+        else
+        {
+            Debug.LogWarning("Battle data was not set");
         }
     }
 

--- a/Assets/Scripts/Controllers/MainMenuController.cs
+++ b/Assets/Scripts/Controllers/MainMenuController.cs
@@ -1,5 +1,9 @@
 using System.Collections;
 using System.Collections.Generic;
+using Cysharp.Threading.Tasks;
+using Nethereum.Hex.HexTypes;
+using Nethereum.RPC.Eth.DTOs;
+using Nethereum.Unity.Rpc;
 using Sirenix.OdinInspector;
 using UnityEngine;
 using UnityEngine.SceneManagement;
@@ -23,7 +27,6 @@ public class MainMenuController : MonoBehaviour
     private void Start()
     {
         ShowScreen(defaultScreenId);
-        _selectDeckListLoader.GetComponent<DeckListLoader>().onItemSelected.AddListener(SelectDeck);
     }
 
     public void ConnectWallet()
@@ -52,11 +55,6 @@ public class MainMenuController : MonoBehaviour
     public void SelectLeague(int leagueId)
     {
         selectedLeagueId = leagueId;
-    }
-
-    public void SelectDeck(ulong deckId)
-    {
-        selectedDeckId = deckId;
     }
 
     public void StartGame()

--- a/Assets/Scripts/Controllers/ScreenEditDeck.cs
+++ b/Assets/Scripts/Controllers/ScreenEditDeck.cs
@@ -42,7 +42,7 @@ public class ScreenEditDeck : MonoBehaviour
         var ownedCardIds = await PepemonFactory.GetOwnedCards(account, PepemonFactoryCardCache.CardsIds);
 
         battleCard = await PepemonCardDeck.GetBattleCard(deckId);
-        supportCards = await PepemonCardDeck.GetAllSupportCards(deckId);
+        supportCards = new Dictionary<ulong, int>(await PepemonCardDeck.GetAllSupportCards(deckId));
 
         deckDisplayComponent.LoadAllBattleCards(ownedCardIds, battleCard);
         deckDisplayComponent.LoadAllSupportCards(ownedCardIds, supportCards);

--- a/Assets/Scripts/Controllers/ScreenEditDeck.cs
+++ b/Assets/Scripts/Controllers/ScreenEditDeck.cs
@@ -14,6 +14,8 @@ public class ScreenEditDeck : MonoBehaviour
 {
     [TitleGroup("Component References"), SerializeField] GameObject _deckDisplay;
     [TitleGroup("Component References"), SerializeField] GameObject _saveDeckButton;
+    [TitleGroup("Component References"), SerializeField] GameObject _mintCardsButton;
+    [TitleGroup("Component References"), SerializeField] GameObject _previousScreenButton;
     [TitleGroup("Component References"), SerializeField] GameObject _textLoading;
     private ulong currentDeckId;
     private ulong battleCard;
@@ -22,6 +24,7 @@ public class ScreenEditDeck : MonoBehaviour
     public void Start()
     {
         _saveDeckButton.GetComponent<Button>().onClick.AddListener(HandleSaveButtonClick);
+        _mintCardsButton.GetComponent<Button>().onClick.AddListener(HandleMintCardsButtonClick);
     }
 
     public async void LoadAllCards(ulong deckId)
@@ -46,9 +49,31 @@ public class ScreenEditDeck : MonoBehaviour
         _textLoading.SetActive(false);
     }
 
-    public async void HandleSaveButtonClick()
+    private void setButtonsInteractibleState(bool interactible)
     {
-        _saveDeckButton.GetComponent<Button>().interactable = false;
+        _saveDeckButton.GetComponent<Button>().interactable = interactible;
+        _previousScreenButton.GetComponent<Button>().interactable = interactible;
+        _mintCardsButton.GetComponent<Button>().interactable = interactible;
+    }
+
+    public async void HandleMintCardsButtonClick()
+    {
+        setButtonsInteractibleState(false);
+        try
+        {
+            await PepemonCardDeck.MintCards();
+            LoadAllCards(currentDeckId);
+        } 
+        finally
+        {
+            setButtonsInteractibleState(true);
+        }
+    }
+
+   public async void HandleSaveButtonClick()
+    {
+        setButtonsInteractibleState(false);
+
         var pepemonCardDeckAddress = Web3Controller.instance.GetChainConfig().pepemonCardDeckAddress;
 
         // necessary to avoid "ERC1155#safeTransferFrom: INVALID_OPERATOR"
@@ -80,7 +105,7 @@ public class ScreenEditDeck : MonoBehaviour
             await UpdateBattlecard(_deckDisplay.GetComponent<DeckDisplay>().GetSelectedBattleCard());
         }
 
-        _saveDeckButton.GetComponent<Button>().interactable = true;
+        setButtonsInteractibleState(true);
     }
 
     private async Task UpdateBattlecard(ulong newBattleCard)

--- a/Assets/Scripts/Controllers/ScreenManageDecks.cs
+++ b/Assets/Scripts/Controllers/ScreenManageDecks.cs
@@ -11,7 +11,7 @@ public class ScreenManageDecks : MonoBehaviour
 
     private void Start()
     {
-        _editDeckListLoader.GetComponent<DeckListLoader>().onItemSelected.AddListener(SelectEditDeck);
+        _editDeckListLoader.GetComponent<DeckListLoader>().onEditDeck.AddListener(SelectEditDeck);
     }
 
     public void SelectEditDeck(ulong deckId)

--- a/Assets/Scripts/Controllers/Web3Controller.cs
+++ b/Assets/Scripts/Controllers/Web3Controller.cs
@@ -12,6 +12,10 @@ using System.Collections.Generic;
 using Nethereum.RPC.Eth.DTOs;
 using Cysharp.Threading.Tasks;
 using System.Threading.Tasks;
+using UnityEngine.UI;
+using Sirenix.OdinInspector;
+using System.Linq;
+using System;
 
 public class Web3Controller : MonoBehaviour
 {
@@ -21,6 +25,42 @@ public class Web3Controller : MonoBehaviour
     public UnityEvent onWalletConnected;
     public int CurrentChainId { get; private set; } = 0;
     public string SelectedAccountAddress { get; private set; }
+
+#if UNITY_EDITOR
+    #region Unity editor button for updating hardhat contracts addresses
+    [Serializable]
+    struct DeploymentJson
+    {
+        public string address;
+    }
+
+    [Button(), PropertyTooltip("Update hardhat's addresses (chainId 31337) from localhost deployment," +
+        "this way there is no need to copy the contracts' addresses from the terminal")]
+    private void UpdateHardhatAddresses()
+    {
+        // use hardhat local deployment assuming that the battle-contracts project is on ../
+        var deployments = @"..\battle-contracts\deployments\localhost";
+        
+        // get hardhat config
+        var chain = settings.chains.FirstOrDefault(x => x.chainId == 31337);
+        var index = Array.IndexOf(settings.chains, chain);
+
+        chain.pepemonBattleAddress = JsonUtility.FromJson<DeploymentJson>(
+            System.IO.File.ReadAllText($@"{deployments}\PepemonBattle.json")).address;
+        Debug.Log("Set pepemonBattleAddress = " + chain.pepemonBattleAddress);
+
+        chain.pepemonCardDeckAddress = JsonUtility.FromJson<DeploymentJson>(
+            System.IO.File.ReadAllText($@"{deployments}\PepemonCardDeck.json")).address;
+        Debug.Log("Set pepemonCardDeckAddress = " + chain.pepemonCardDeckAddress);
+
+        chain.pepemonMatchmakerAddresses[0] = JsonUtility.FromJson<DeploymentJson>(
+            System.IO.File.ReadAllText($@"{deployments}\PepemonMatchmaker.json")).address;
+        Debug.Log("Set pepemonMatchmakerAddresses[0] = " + chain.pepemonMatchmakerAddresses[0]);
+
+        settings.chains[index] = chain;
+    }
+    #endregion
+#endif
 
 #if !UNITY_EDITOR
     private bool _isMetamaskInitialised = false;

--- a/Assets/Scripts/Controllers/Web3Settings.cs
+++ b/Assets/Scripts/Controllers/Web3Settings.cs
@@ -21,6 +21,7 @@ public class Web3Settings
         public string pepemonBattleAddress;
         public string pepemonFactoryAddress;
         public string pepemonCardDeckAddress;
+        public string[] pepemonMatchmakerAddresses;
     }
 
     public Web3ChainConfig GetChainConfig(int chainId)

--- a/Assets/Scripts/Data/Card.cs
+++ b/Assets/Scripts/Data/Card.cs
@@ -50,7 +50,7 @@ public class Card : ScriptableObject
     [ShowIf("@this.Type == PlayCardType.Defense || this.Type == PlayCardType.SpecialDefense")] public int DefensePower;
 
     [TitleGroup("Properties")]
-    public EffectOne[] effectOnes;
+    public EffectOne effectOne;
 
     [TitleGroup("Properties")]
     public EffectMany effectMany;

--- a/Assets/Scripts/Data/Card.cs
+++ b/Assets/Scripts/Data/Card.cs
@@ -1,5 +1,6 @@
 using UnityEngine;
 using Sirenix.OdinInspector;
+using System;
 
 [CreateAssetMenu(fileName = "Data", menuName = "ScriptableObjects/card", order = 1)]
 public class Card : ScriptableObject
@@ -40,11 +41,19 @@ public class Card : ScriptableObject
     [LabelWidth(80)]
     public Sprite CardEffectSprite;
 
+    [Obsolete("shouldnt be used anymore")]
     [TitleGroup("Properties")]
     [ShowIf("@this.Type == PlayCardType.Offense || this.Type == PlayCardType.SpecialOffense")] public int AttackPower;
 
+    [Obsolete("shouldnt be used anymore")]
     [TitleGroup("Properties")]
     [ShowIf("@this.Type == PlayCardType.Defense || this.Type == PlayCardType.SpecialDefense")] public int DefensePower;
+
+    [TitleGroup("Properties")]
+    public EffectOne[] effectOnes;
+
+    [TitleGroup("Properties")]
+    public EffectMany effectMany;
 
     [TitleGroup("Properties")]
     public bool Unstackable;

--- a/Assets/Scripts/Data/Card.cs
+++ b/Assets/Scripts/Data/Card.cs
@@ -41,11 +41,11 @@ public class Card : ScriptableObject
     [LabelWidth(80)]
     public Sprite CardEffectSprite;
 
-    [Obsolete("shouldnt be used anymore")]
+    [Obsolete("not used")]
     [TitleGroup("Properties")]
     [ShowIf("@this.Type == PlayCardType.Offense || this.Type == PlayCardType.SpecialOffense")] public int AttackPower;
 
-    [Obsolete("shouldnt be used anymore")]
+    [Obsolete("not used")]
     [TitleGroup("Properties")]
     [ShowIf("@this.Type == PlayCardType.Defense || this.Type == PlayCardType.SpecialDefense")] public int DefensePower;
 
@@ -61,7 +61,9 @@ public class Card : ScriptableObject
     [TitleGroup("Properties")]
     public bool Unresettable;
 
+    [Obsolete("not used")]
     [TitleGroup("Additionals"), ShowIf("Unstackable")] public int UnstackableAmount;
+    [Obsolete("not used")]
     [TitleGroup("Additionals"), ShowIf("Unresettable")] public int UnresettableAmount;
 
 

--- a/Assets/Scripts/Data/DataContainer.cs
+++ b/Assets/Scripts/Data/DataContainer.cs
@@ -1,0 +1,45 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+
+[CreateAssetMenu(menuName = "Containers/Cards data container")]
+public class DataContainer : ScriptableObject
+{
+    // should contain all pepemons/cards scriptable objects currently in the game
+    public List<Pepemon> Pepemons;
+    public List<Card> Cards;
+
+    // returns all cards (repeating them when necessary)
+    public IEnumerable<Card> GetAllCardsByIds(Dictionary<ulong, int> cards)
+    {
+        foreach (var supportCard in GetCardsTypesByIds(cards.Keys.ToList()))
+        {
+            if (supportCard != null)
+            {
+                if (!cards.TryGetValue((ulong)supportCard.ID, out var copies))
+                {
+                    Debug.LogWarning("Card ID not found: " + supportCard.ID);
+                    continue;
+                }
+                foreach (var card in Enumerable.Repeat(supportCard, copies))
+                {
+                    yield return card;
+                }
+            }
+        }
+    }
+
+    public IEnumerable<Card> GetCardsTypesByIds(List<ulong> ids)
+    {
+        foreach (var id in ids)
+        {
+            yield return Cards.FirstOrDefault(card => (ulong)card.ID == id);
+        }
+    }
+
+    public Pepemon GetPepemonById(string id)
+    {
+        return Pepemons.FirstOrDefault(pepemon => pepemon.ID == id);
+    }
+}

--- a/Assets/Scripts/Data/DataContainer.cs
+++ b/Assets/Scripts/Data/DataContainer.cs
@@ -11,7 +11,7 @@ public class DataContainer : ScriptableObject
     public List<Card> Cards;
 
     // returns all cards (repeating them when necessary)
-    public IEnumerable<Card> GetAllCardsByIds(Dictionary<ulong, int> cards)
+    public IEnumerable<Card> GetAllCardsByIds(IDictionary<ulong, int> cards)
     {
         foreach (var supportCard in GetCardsTypesByIds(cards.Keys.ToList()))
         {

--- a/Assets/Scripts/Data/DataContainer.cs.meta
+++ b/Assets/Scripts/Data/DataContainer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a2c44b48e521c2541889fa242f78de1c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Data/Deck.cs
+++ b/Assets/Scripts/Data/Deck.cs
@@ -1,4 +1,7 @@
 using System.Collections.Generic;
+using System.Numerics;
+using Nethereum.ABI;
+using Nethereum.RLP;
 using Sirenix.OdinInspector;
 using UnityEngine;
 
@@ -14,19 +17,21 @@ public class Deck
 
     // This uses the Fisher-Yates shuffle algorithm to randomly sort elements.
     // It is an accurate, effective shuffling method for all array types.
-    public void ShuffelDeck(int seed)
+    public void ShuffelDeck(BigInteger seed)
     {
-        System.Random _random = new System.Random(seed);
-        Card _cacheCard;
+        // calculate random seed like in solidity
+        var abiEncode = new ABIEncode();
 
-        int n = AllCards.Count;
-        for (int i = 0; i < n; i++)
+        for (int i = 0; i < AllCards.Count; i++)
         {
-            // NextDouble returns a random number between 0 and 1 ..It is equivalent to Math.random()
-            int r = i + (int)(_random.NextDouble() * (n - i));
-            _cacheCard = AllCards[r];
-            AllCards[r] = AllCards[i];
-            AllCards[i] = _cacheCard;
+            var n = i + seed % (AllCards.Count - i);
+            var temp = AllCards[(int)n];
+            AllCards[(int)n] = AllCards[i];
+            AllCards[i] = temp;
+
+            seed = abiEncode
+                .GetSha3ABIEncodedPacked(new ABIValue("uint256", seed))
+                .ToBigIntegerFromRLPDecoded();
         }
     }
 

--- a/Assets/Scripts/Data/Enums.cs
+++ b/Assets/Scripts/Data/Enums.cs
@@ -8,17 +8,17 @@ public enum PlayCardType
 
 public enum PepemonType
 {
-    Plant,
     Fire,
+    Grass,
+    Water,
     Lightning,
     Wind,
     Poison,
-    Earth,
-    Grass,
-    Unknown,
     Ghost,
     Fairy,
-    Water
+    Earth,
+    Unknown,
+    None,
 }
 
 public enum CardRarity

--- a/Assets/Scripts/Data/Enums.cs
+++ b/Assets/Scripts/Data/Enums.cs
@@ -6,7 +6,6 @@ public enum PlayCardType
     SpecialDefense
 }
 
-
 public enum PepemonType
 {
     Plant,
@@ -27,4 +26,20 @@ public enum CardRarity
     Common,
     Rare,
     Epic
+}
+
+public enum EffectTo
+{
+    Attack,
+    SpecialAttack,
+    Defense,
+    SpecialDefense,
+    Speed,
+    Intelligence
+}
+
+public enum EffectFor
+{
+    Me,
+    Enemy
 }

--- a/Assets/Scripts/Data/Hand.cs
+++ b/Assets/Scripts/Data/Hand.cs
@@ -8,6 +8,7 @@ public class Hand
 {
     [ShowInInspector]
     private List<Card> _cardsInHand = new List<Card>();
+    private List<Card> _tableSupportCards = new List<Card>();
 
     public List<Card> AllOffenseCards => _cardsInHand.Where(x => x.Type == PlayCardType.Offense).ToList();
     public List<Card> AllDefenseCards => _cardsInHand.Where(x => x.Type == PlayCardType.Defense).ToList();
@@ -16,8 +17,10 @@ public class Hand
 
     public void ClearHand() => _cardsInHand.Clear();
     public void AddCardToHand(Card card) => _cardsInHand.Add(card);
-    public void RemoveCardFromHand(Card card) => _cardsInHand.Remove(card);
     public List<Card> GetCardsInHand => _cardsInHand;
+    public List<Card> GetTableSupportCards => _tableSupportCards;
+    public void AddCardToTable(Card card) => _tableSupportCards.Add(card);
+    public void RemoveCardFromTable(Card card) => _tableSupportCards.Remove(card);
 
 
     public void RemoveAllOffenseCards()

--- a/Assets/Scripts/Data/Player.cs
+++ b/Assets/Scripts/Data/Player.cs
@@ -153,7 +153,7 @@ public class Player
                 // Decrease effect numTurns by 1 since 1 turn has already passed
                 effect.numTurns--;
 
-                // Delete this one from tableSupportCardStat if all turns of the card have been exhausted
+                // Delete this one if all turns of the card have been exhausted
                 if (effect.numTurns == 0)
                 {
                     toBeRemoved.Add(card);

--- a/Assets/Scripts/Data/Player.cs
+++ b/Assets/Scripts/Data/Player.cs
@@ -2,6 +2,9 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using Sirenix.OdinInspector;
+using System.Numerics;
+using Nethereum.ABI;
+using Nethereum.RLP;
 
 [System.Serializable]
 public class Player
@@ -28,12 +31,20 @@ public class Player
         PlayerDeck.GetDeck().AddRange(supportCards);
     }
 
-    public void GetAndShuffelDeck(int seed)
+    public void GetAndShuffelDeck(BigInteger seed, BigInteger currentTurn, BigInteger battleRng)
     {
         // Get local copy of deck and shuffle
         CurrentDeck.ClearDeck();
         CurrentDeck.GetDeck().AddRange(PlayerDeck.GetDeck());
-        CurrentDeck.ShuffelDeck(seed);
+
+        // calculate random seed like in solidity
+        var abiEncode = new ABIEncode();
+        CurrentDeck.ShuffelDeck(
+            abiEncode.GetSha3ABIEncodedPacked(
+                new ABIValue("uint256", seed),
+                new ABIValue("uint256", currentTurn),
+                new ABIValue("uint256", battleRng)
+             ).ToBigIntegerFromRLPDecoded());
     }
 
     public void DrawNewHand()

--- a/Assets/Scripts/Data/Player.cs
+++ b/Assets/Scripts/Data/Player.cs
@@ -113,7 +113,7 @@ public class Player
         var toBeRemoved = new List<Card>();
 
         //Loop through every support card currently played
-        foreach (var card in CurrentHand.GetCardsInHand)
+        foreach (var card in CurrentHand.GetTableSupportCards)
         {
             //Get the effect of that support card
             var effect = card.effectMany;
@@ -163,7 +163,7 @@ public class Player
 
         foreach (var card in toBeRemoved)
         {
-            CurrentHand.RemoveCardFromHand(card);
+            CurrentHand.RemoveCardFromTable(card);
         }
     }
 }

--- a/Assets/Scripts/Data/Player.cs
+++ b/Assets/Scripts/Data/Player.cs
@@ -17,6 +17,7 @@ public class Player
     [BoxGroup("Runtime")] public Deck CurrentDeck;
     [BoxGroup("Runtime")] public Hand CurrentHand;
     [BoxGroup("Runtime")] public int StartingIndex;
+    [BoxGroup("Runtime")] public int PlayedCardCount;
     [BoxGroup("Runtime")] public CurrentBattleCardStats CurrentPepemonStats = new(); // all stats of the player's battle cards currently
 
 
@@ -66,18 +67,13 @@ public class Player
         CurrentHand.ClearHand();
 
         // Draw cards to hand
-        List<Card> cacheList = new List<Card>();
-        for (int i = 0; i < PlayerPepemon.Intelligence; i++)
+        // Note: Same logic of the contract PepemonBattle.sol
+        for (int i = 0; i < CurrentPepemonStats.inte; i++)
         {
-            if (i >= 0 && i < CurrentDeck.GetDeck().Count)
-            {
-                CurrentHand.AddCardToHand(CurrentDeck.GetDeck()[i]);
-                cacheList.Add(CurrentDeck.GetDeck()[i]);
-            }
+            CurrentHand.AddCardToHand(CurrentDeck.GetDeck()[(i + PlayedCardCount) % CurrentDeck.GetDeck().Count]);
         }
 
-        // Cleanup working decks
-        foreach (var item in cacheList) CurrentDeck.RemoveCard(item);
+        PlayedCardCount += CurrentPepemonStats.inte;
     }
 
 
@@ -110,6 +106,7 @@ public class Player
     }
 #endif
 
+    // Note: Same logic of the contract PepemonBattle.sol
     // This method calculates the battle card's stats after taking into consideration all the support cards currently being played
     public void CalcSupportCardsOnTable(Player opponent)
     {

--- a/Assets/Scripts/Data/Player.cs
+++ b/Assets/Scripts/Data/Player.cs
@@ -5,6 +5,7 @@ using Sirenix.OdinInspector;
 using System.Numerics;
 using Nethereum.ABI;
 using Nethereum.RLP;
+using System;
 
 [System.Serializable]
 public class Player
@@ -16,6 +17,7 @@ public class Player
     [BoxGroup("Runtime")] public Deck CurrentDeck;
     [BoxGroup("Runtime")] public Hand CurrentHand;
     [BoxGroup("Runtime")] public int StartingIndex;
+    [BoxGroup("Runtime")] public CurrentBattleCardStats CurrentPepemonStats = new(); // all stats of the player's battle cards currently
 
 
     public void Initialise(int index)
@@ -45,6 +47,17 @@ public class Player
                 new ABIValue("uint256", currentTurn),
                 new ABIValue("uint256", battleRng)
              ).ToBigIntegerFromRLPDecoded());
+    }
+
+    // Reset player's hand infos to base stats
+    public void ResetCurrentPepemonStats()
+    {
+        CurrentPepemonStats.spd = PlayerPepemon.Speed;
+        CurrentPepemonStats.inte = PlayerPepemon.Intelligence;
+        CurrentPepemonStats.atk = PlayerPepemon.Attack;
+        CurrentPepemonStats.def = PlayerPepemon.Defense;
+        CurrentPepemonStats.sAtk = PlayerPepemon.SAttack;
+        CurrentPepemonStats.sDef = PlayerPepemon.SDeffense;
     }
 
     public void DrawNewHand()
@@ -96,4 +109,64 @@ public class Player
         }
     }
 #endif
+
+    // This method calculates the battle card's stats after taking into consideration all the support cards currently being played
+    public void CalcSupportCardsOnTable(Player opponent)
+    {
+        var toBeRemoved = new List<Card>();
+
+        //Loop through every support card currently played
+        foreach (var card in CurrentHand.GetCardsInHand)
+        {
+            //Get the effect of that support card
+            var effect = card.effectMany;
+
+            //If there is at least 1 turn left
+            if (effect.numTurns >= 1)
+            {
+                var pepemonToBeAffected = opponent.CurrentPepemonStats;
+
+                //If the effect is for me
+                if (effect.effectFor == EffectFor.Me)
+                {
+                    pepemonToBeAffected = CurrentPepemonStats;
+                }
+
+                // Change card's stats using that support card
+                // Currently effectTo of EffectMany can be ATTACK, DEFENSE, SPEED and INTELLIGENCE
+                // Get the statistic changed and update it 
+                // Intelligence can't go into the negatives
+                if (effect.effectTo == EffectTo.Attack)
+                {
+                    pepemonToBeAffected.atk += effect.power;
+                }
+                else if (effect.effectTo == EffectTo.Defense)
+                {
+                    pepemonToBeAffected.def += effect.power;
+                }
+                else if (effect.effectTo == EffectTo.Speed)
+                {
+                    pepemonToBeAffected.spd += effect.power;
+                }
+                else if (effect.effectTo == EffectTo.Intelligence)
+                {
+                    pepemonToBeAffected.inte = Math.Max(pepemonToBeAffected.inte + effect.power, 0);
+                }
+
+                // Decrease effect numTurns by 1 since 1 turn has already passed
+                effect.numTurns--;
+
+                // Delete this one from tableSupportCardStat if all turns of the card have been exhausted
+                if (effect.numTurns == 0)
+                {
+                    toBeRemoved.Add(card);
+                }
+            }
+        }
+
+        foreach (var card in toBeRemoved)
+        {
+            CurrentHand.RemoveCardFromHand(card);
+        }
+    }
 }

--- a/Assets/Scripts/Data/Player.cs
+++ b/Assets/Scripts/Data/Player.cs
@@ -68,9 +68,10 @@ public class Player
 
         // Draw cards to hand
         // Note: Same logic of the contract PepemonBattle.sol
+        CurrentPepemonStats.inte = Math.Min(CurrentPepemonStats.inte, CurrentDeck.GetDeck().Count - PlayedCardCount);
         for (int i = 0; i < CurrentPepemonStats.inte; i++)
         {
-            CurrentHand.AddCardToHand(CurrentDeck.GetDeck()[(i + PlayedCardCount) % CurrentDeck.GetDeck().Count]);
+            CurrentHand.AddCardToHand(CurrentDeck.GetDeck()[(i + PlayedCardCount)]);
         }
 
         PlayedCardCount += CurrentPepemonStats.inte;

--- a/Assets/Scripts/Data/Player.cs
+++ b/Assets/Scripts/Data/Player.cs
@@ -21,6 +21,13 @@ public class Player
         StartingIndex = index;
     }
 
+    public void SetPlayerDeck(Pepemon pepemon, IEnumerable<Card> supportCards)
+    {
+        PlayerPepemon = pepemon;
+        PlayerDeck.ClearDeck();
+        PlayerDeck.GetDeck().AddRange(supportCards);
+    }
+
     public void GetAndShuffelDeck(int seed)
     {
         // Get local copy of deck and shuffle

--- a/Assets/Scripts/Data/Structs.cs
+++ b/Assets/Scripts/Data/Structs.cs
@@ -1,0 +1,41 @@
+﻿
+using System;
+using UnityEngine;
+
+//spd, inte, def, atk, sAtk, sDef - Current stats of battle card (with powerups included)
+//Each param can go into the negatives
+[Serializable]
+public struct CurrentBattleCardStats
+{
+    public int spd { get; set; }
+    public int inte { get; set; }
+    public int def { get; set; }
+    public int atk { get; set; }
+    public int sAtk { get; set; }
+    public int sDef { get; set; }
+}
+
+[Serializable]
+public struct EffectOne
+{
+    // If power is 0, it is equal to the total of all normal offense/defense cards in the current turn.
+
+    //basePower = power if req not met
+    [SerializeField] public int basePower { get; set; }
+
+    //triggeredPower = power if req met
+    [SerializeField] public int triggeredPower { get; set; }
+    [SerializeField] public EffectTo effectTo { get; set; }
+    [SerializeField] public EffectFor effectFor { get; set; }
+    [SerializeField] public int reqCode { get; set; } //requirement code
+}
+
+[Serializable]
+public struct EffectMany
+{
+    [SerializeField] public int power { get; set; }
+    [SerializeField] public int numTurns { get; set; }
+    [SerializeField] public EffectTo effectTo { get; set; }
+    [SerializeField] public EffectFor effectFor { get; set; }
+    [SerializeField] public int reqCode { get; set; } //requirement code
+}

--- a/Assets/Scripts/Data/Structs.cs
+++ b/Assets/Scripts/Data/Structs.cs
@@ -1,6 +1,5 @@
 ﻿
 using System;
-using Sirenix.OdinInspector;
 
 //spd, inte, def, atk, sAtk, sDef - Current stats of battle card (with powerups included)
 //Each param can go into the negatives
@@ -21,21 +20,21 @@ public struct EffectOne
     // If power is 0, it is equal to the total of all normal offense/defense cards in the current turn.
 
     //basePower = power if req not met
-    [ShowInInspector] public int basePower { get; set; }
+    public int basePower;
 
     //triggeredPower = power if req met
-    [ShowInInspector] public int triggeredPower { get; set; }
-    [ShowInInspector] public EffectTo effectTo { get; set; }
-    [ShowInInspector] public EffectFor effectFor { get; set; }
-    [ShowInInspector] public int reqCode { get; set; } //requirement code
+    public int triggeredPower;
+    public EffectTo effectTo;
+    public EffectFor effectFor;
+    public int reqCode; //requirement code
 }
 
 [Serializable]
 public struct EffectMany
 {
-    [ShowInInspector] public int power { get; set; }
-    [ShowInInspector] public int numTurns { get; set; }
-    [ShowInInspector] public EffectTo effectTo { get; set; }
-    [ShowInInspector] public EffectFor effectFor { get; set; }
-    [ShowInInspector] public int reqCode { get; set; } //requirement code
+    public int power;
+    public int numTurns;
+    public EffectTo effectTo;
+    public EffectFor effectFor;
+    public int reqCode; //requirement code
 }

--- a/Assets/Scripts/Data/Structs.cs
+++ b/Assets/Scripts/Data/Structs.cs
@@ -1,6 +1,6 @@
 ﻿
 using System;
-using UnityEngine;
+using Sirenix.OdinInspector;
 
 //spd, inte, def, atk, sAtk, sDef - Current stats of battle card (with powerups included)
 //Each param can go into the negatives
@@ -21,21 +21,21 @@ public struct EffectOne
     // If power is 0, it is equal to the total of all normal offense/defense cards in the current turn.
 
     //basePower = power if req not met
-    [SerializeField] public int basePower { get; set; }
+    [ShowInInspector] public int basePower { get; set; }
 
     //triggeredPower = power if req met
-    [SerializeField] public int triggeredPower { get; set; }
-    [SerializeField] public EffectTo effectTo { get; set; }
-    [SerializeField] public EffectFor effectFor { get; set; }
-    [SerializeField] public int reqCode { get; set; } //requirement code
+    [ShowInInspector] public int triggeredPower { get; set; }
+    [ShowInInspector] public EffectTo effectTo { get; set; }
+    [ShowInInspector] public EffectFor effectFor { get; set; }
+    [ShowInInspector] public int reqCode { get; set; } //requirement code
 }
 
 [Serializable]
 public struct EffectMany
 {
-    [SerializeField] public int power { get; set; }
-    [SerializeField] public int numTurns { get; set; }
-    [SerializeField] public EffectTo effectTo { get; set; }
-    [SerializeField] public EffectFor effectFor { get; set; }
-    [SerializeField] public int reqCode { get; set; } //requirement code
+    [ShowInInspector] public int power { get; set; }
+    [ShowInInspector] public int numTurns { get; set; }
+    [ShowInInspector] public EffectTo effectTo { get; set; }
+    [ShowInInspector] public EffectFor effectFor { get; set; }
+    [ShowInInspector] public int reqCode { get; set; } //requirement code
 }

--- a/Assets/Scripts/Data/Structs.cs.meta
+++ b/Assets/Scripts/Data/Structs.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 62ebd735300cab44f84be8ef5546d9da
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Extensions/NethereumExtensions.cs
+++ b/Assets/Scripts/Extensions/NethereumExtensions.cs
@@ -105,7 +105,7 @@ public static class NethereumExtensions
     )
     where _IEventDTO : IEventDTO, new()
     {
-        var getLogsRequest = new EthGetLogsUnityRequest(Web3Controller.instance.GetUnityRpcRequestClientFactory());
+        EthGetLogsUnityRequest getLogsRequest;
 
         Debug.Log($"Waiting for event: {typeof(_IEventDTO).Name} " +
             $"with {eventFilter.Topics.Length} topics " +
@@ -114,6 +114,7 @@ public static class NethereumExtensions
         List<EventLog<_IEventDTO>> eventLogs;
         do
         {
+            getLogsRequest = new EthGetLogsUnityRequest(Web3Controller.instance.GetUnityRpcRequestClientFactory());
             await getLogsRequest.SendRequest(eventFilter);
             eventLogs = getLogsRequest.Result.DecodeAllEvents<_IEventDTO>();
             

--- a/Assets/Scripts/Extensions/NethereumExtensions.cs
+++ b/Assets/Scripts/Extensions/NethereumExtensions.cs
@@ -81,6 +81,22 @@ public static class NethereumExtensions
         return blockParamInstance;
     }
 
+    public static async Task<List<EventLog<_IEventDTO>>> GetEventsAsync<_IEventDTO>(this NewFilterInput eventFilter)
+        where _IEventDTO : IEventDTO, new()
+    {
+        var getLogsRequest = new EthGetLogsUnityRequest(Web3Controller.instance.GetUnityRpcRequestClientFactory());
+        Debug.Log($"Getting events: {typeof(_IEventDTO).Name} " +
+            $"with {eventFilter.Topics.Length} filter params " +
+            $"from blocks {eventFilter.FromBlock.BlockNumber} - {eventFilter.ToBlock.BlockNumber}");
+
+        List<EventLog<_IEventDTO>> eventLogs;
+        await getLogsRequest.SendRequest(eventFilter);
+        eventLogs = getLogsRequest.Result.DecodeAllEvents<_IEventDTO>();
+
+        Debug.Log("Events received: " + eventLogs.Count);
+        return eventLogs;
+    }
+
     public static async Task<List<EventLog<_IEventDTO>>> WaitForEventAsync<_IEventDTO>(
         this NewFilterInput eventFilter,
         int millisecondsToWait = EVENT_POLLING_INTERVAL_MS,

--- a/Assets/Scripts/Extensions/OrderedDictionary.cs
+++ b/Assets/Scripts/Extensions/OrderedDictionary.cs
@@ -1,0 +1,277 @@
+﻿using System.Collections.Specialized;
+using System.Linq;
+using JetBrains.Annotations;
+
+// see https://stackoverflow.com/a/35992747
+
+// ReSharper disable CheckNamespace -- be available where Dictionary<,> is
+
+namespace System.Collections.Generic
+{
+    /// <summary>
+    ///     System.Collections.Specialized.OrderedDictionary is NOT generic.
+    ///     This class is essentially a generic wrapper for OrderedDictionary.
+    ///     https://github.com/Microsoft/referencesource/blob/master/System.ServiceModel.Internals/System/Runtime/Collections/OrderedDictionary.cs
+    /// </summary>
+    /// <remarks>
+    ///     Indexer here will NOT throw KeyNotFoundException
+    /// </remarks>
+    public class OrderedDictionary<TKey, TValue> : IDictionary<TKey, TValue>, IDictionary
+    {
+        private readonly OrderedDictionary _privateDictionary;
+
+        /// <summary>
+        /// Initializes a new mutable instance of the <see cref="OrderedDictionary{TKey, TValue}"/> class.
+        /// </summary>
+        public OrderedDictionary()
+        {
+            _privateDictionary = new OrderedDictionary();
+        }
+
+        /// <summary>
+        /// Initializes a new READ ONLY instance of the <see cref="OrderedDictionary{TKey, TValue}"/> class.
+        /// </summary>
+        /// <param name="dictionary">The dictionary.</param>
+        /// <exception cref="System.ArgumentNullException"></exception>
+        private OrderedDictionary([NotNull] IDictionary<TKey, TValue> dictionary)
+        {
+            if (dictionary == null) throw new ArgumentNullException(nameof(dictionary));
+
+            var orderedDictionary = new OrderedDictionary(dictionary.Count);
+
+            foreach (var pair in dictionary)
+            {
+                orderedDictionary.Add(pair.Key, pair.Value);
+            }
+
+            _privateDictionary = orderedDictionary.AsReadOnly();
+        }
+
+        int ICollection.Count => _privateDictionary.Count;
+        object ICollection.SyncRoot => ((ICollection)_privateDictionary).SyncRoot;
+        bool ICollection.IsSynchronized => ((ICollection)_privateDictionary).IsSynchronized;
+        void ICollection.CopyTo(Array array, int index) => _privateDictionary.CopyTo(array, index);
+
+        ICollection IDictionary.Keys => _privateDictionary.Keys;
+        ICollection IDictionary.Values => _privateDictionary.Values;
+        bool IDictionary.IsFixedSize => ((IDictionary)_privateDictionary).IsFixedSize;
+        bool IDictionary.IsReadOnly => _privateDictionary.IsReadOnly;
+        void IDictionary.Add(object key, object value) => _privateDictionary.Add(key, value);
+        void IDictionary.Clear() => _privateDictionary.Clear();
+        bool IDictionary.Contains(object key) => _privateDictionary.Contains(key);
+        void IDictionary.Remove(object key) => _privateDictionary.Remove(key);
+        IDictionaryEnumerator IDictionary.GetEnumerator() => _privateDictionary.GetEnumerator();
+
+        object IDictionary.this[object key]
+        {
+            get { return _privateDictionary[key]; }
+            set { _privateDictionary[key] = value; }
+        }
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+        public IEnumerator<KeyValuePair<TKey, TValue>> GetEnumerator()
+        {
+            var enumerable = from DictionaryEntry entry in _privateDictionary
+                             select new KeyValuePair<TKey, TValue>((TKey)entry.Key, (TValue)entry.Value);
+
+            return enumerable.GetEnumerator();
+        }
+
+        public bool IsReadOnly => _privateDictionary.IsReadOnly;
+        public int Count => _privateDictionary.Count;
+
+        /// <summary>
+        ///     Gets or sets the <see cref="TValue" /> with the specified key.
+        /// </summary>
+        /// <value>
+        ///     The <see cref="TValue" />.
+        /// </value>
+        /// <param name="key">The key.</param>
+        /// <returns></returns>
+        /// <exception cref="System.ArgumentNullException">key</exception>
+        public TValue this[TKey key]
+        {
+            get
+            {
+                if (key == null) throw new ArgumentNullException(nameof(key));
+
+                if (_privateDictionary.Contains(key))
+                {
+                    return (TValue)_privateDictionary[key];
+                }
+
+                return default(TValue);
+            }
+            set
+            {
+                if (key == null) throw new ArgumentNullException(nameof(key));
+
+                _privateDictionary[key] = value;
+            }
+        }
+
+        public ICollection<TKey> Keys
+        {
+            get
+            {
+                var keys = new List<TKey>(_privateDictionary.Count);
+
+                keys.AddRange(_privateDictionary.Keys.Cast<TKey>());
+
+                return keys.AsReadOnly();
+            }
+        }
+
+        public ICollection<TValue> Values
+        {
+            get
+            {
+                var values = new List<TValue>(_privateDictionary.Count);
+
+                values.AddRange(_privateDictionary.Values.Cast<TValue>());
+
+                return values.AsReadOnly();
+            }
+        }
+
+        public void Add(KeyValuePair<TKey, TValue> item) => Add(item.Key, item.Value);
+
+        /// <summary>
+        ///     Adds an element with the provided key and value to the <see cref="T:System.Collections.Generic.IDictionary`2" />.
+        /// </summary>
+        /// <param name="key">The object to use as the key of the element to add.</param>
+        /// <param name="value">The object to use as the value of the element to add.</param>
+        /// <exception cref="System.ArgumentNullException">key</exception>
+        public void Add(TKey key, TValue value)
+        {
+            if (key == null) throw new ArgumentNullException(nameof(key));
+
+            _privateDictionary.Add(key, value);
+        }
+
+        public void Clear() => _privateDictionary.Clear();
+
+        public bool Contains(KeyValuePair<TKey, TValue> item)
+        {
+            if (item.Key == null || !_privateDictionary.Contains(item.Key)) return false;
+
+            return _privateDictionary[item.Key].Equals(item.Value);
+        }
+
+        /// <summary>
+        ///     Determines whether the <see cref="T:System.Collections.Generic.IDictionary`2" /> contains an element with the
+        ///     specified key.
+        /// </summary>
+        /// <param name="key">The key to locate in the <see cref="T:System.Collections.Generic.IDictionary`2" />.</param>
+        /// <returns>
+        ///     true if the <see cref="T:System.Collections.Generic.IDictionary`2" /> contains an element with the key; otherwise,
+        ///     false.
+        /// </returns>
+        /// <exception cref="System.ArgumentNullException">key</exception>
+        public bool ContainsKey(TKey key)
+        {
+            if (key == null) throw new ArgumentNullException(nameof(key));
+
+            return _privateDictionary.Contains(key);
+        }
+
+        /// <summary>
+        ///     Copies the elements of the <see cref="T:System.Collections.Generic.ICollection`1" /> to an
+        ///     <see cref="T:System.Array" />, starting at a particular <see cref="T:System.Array" /> index.
+        /// </summary>
+        /// <param name="array">
+        ///     The one-dimensional <see cref="T:System.Array" /> that is the destination of the elements copied
+        ///     from <see cref="T:System.Collections.Generic.ICollection`1" />. The <see cref="T:System.Array" /> must have
+        ///     zero-based indexing.
+        /// </param>
+        /// <param name="arrayIndex">The zero-based index in <paramref name="array" /> at which copying begins.</param>
+        /// <exception cref="System.ArgumentNullException">array</exception>
+        /// <exception cref="System.ArgumentOutOfRangeException">arrayIndex is &lt; 0</exception>
+        /// <exception cref="System.ArgumentException">
+        ///     Cannot copy to array, array dimensions insufficient
+        /// </exception>
+        public void CopyTo(KeyValuePair<TKey, TValue>[] array, int arrayIndex = 0)
+        {
+            if (array == null) throw new ArgumentNullException(nameof(array));
+            if (arrayIndex < 0) throw new ArgumentOutOfRangeException(nameof(arrayIndex));
+            if (array.Rank > 1) throw new ArgumentException($"array.Rank of {array.Rank} exceeds dimensions allowed (1)");
+            if (arrayIndex >= array.Length || array.Length - arrayIndex < _privateDictionary.Count)
+                throw new ArgumentException("Cannot copy to array, array dimensions insufficient", nameof(array));
+
+            var index = arrayIndex;
+            foreach (DictionaryEntry entry in _privateDictionary)
+            {
+                array[index] = new KeyValuePair<TKey, TValue>((TKey)entry.Key, (TValue)entry.Value);
+                index++;
+            }
+        }
+
+        public bool Remove(KeyValuePair<TKey, TValue> item)
+        {
+            if (false == Contains(item)) return false;
+
+            _privateDictionary.Remove(item.Key);
+
+            return true;
+        }
+
+        /// <summary>
+        ///     Removes the element with the specified key from the <see cref="T:System.Collections.Generic.IDictionary`2" />.
+        /// </summary>
+        /// <param name="key">The key of the element to remove.</param>
+        /// <returns>
+        ///     true if the element is successfully removed; otherwise, false.
+        /// </returns>
+        /// <exception cref="System.ArgumentNullException">key</exception>
+        public bool Remove(TKey key)
+        {
+            if (key == null) throw new ArgumentNullException(nameof(key));
+
+            if (false == _privateDictionary.Contains(key)) return false;
+
+            _privateDictionary.Remove(key);
+
+            return true;
+        }
+
+        /// <summary>
+        ///     Gets the value associated with the specified key.
+        /// </summary>
+        /// <param name="key">The key whose value to get.</param>
+        /// <param name="value">
+        ///     When this method returns, the value associated with the specified key, if the key is found;
+        ///     otherwise, the default value for the type of the <paramref name="value" /> parameter. This parameter is passed
+        ///     uninitialized.
+        /// </param>
+        /// <returns>
+        ///     true if the object that implements <see cref="T:System.Collections.Generic.IDictionary`2" /> contains an element
+        ///     with the specified key; otherwise, false.
+        /// </returns>
+        /// <exception cref="System.ArgumentNullException">key</exception>
+        public bool TryGetValue(TKey key, out TValue value)
+        {
+            if (key == null) throw new ArgumentNullException(nameof(key));
+
+            var keyExists = _privateDictionary.Contains(key);
+
+            value = keyExists ? (TValue)_privateDictionary[key] : default(TValue);
+
+            return keyExists;
+        }
+
+        /// <summary>
+        ///     Creates a read only ordered dictionary by copying key value pairs.
+        /// </summary>
+        /// <param name="dictionary">The dictionary.</param>
+        /// <returns>Read only ordered dictionary containing the elements in dictionary</returns>
+        public static OrderedDictionary<TKey, TValue> CreateReadOnly([NotNull] IDictionary<TKey, TValue> dictionary)
+            => new OrderedDictionary<TKey, TValue>(dictionary);
+
+        /// <summary>
+        ///     Copies the key value pairs of this dictionary into a new read only ordered dictionary
+        /// </summary>
+        /// <returns>Read only ordered dictionary containing the same elements</returns>
+        public OrderedDictionary<TKey, TValue> AsReadOnly() => new OrderedDictionary<TKey, TValue>(this);
+    }
+}

--- a/Assets/Scripts/Extensions/OrderedDictionary.cs.meta
+++ b/Assets/Scripts/Extensions/OrderedDictionary.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fdde80b9bd5a78540a248ffc81c24887
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/UI/Loaders/DeckListLoader.cs
+++ b/Assets/Scripts/UI/Loaders/DeckListLoader.cs
@@ -12,10 +12,10 @@ public class DeckListLoader : MonoBehaviour
     [TitleGroup("Component References"), SerializeField] GameObject _deckPrefab;
     [TitleGroup("Component References"), SerializeField] GameObject _deckList;
     [TitleGroup("Component References"), SerializeField] GameObject _loadingMessage;
-    // Whether or not display the pen + transparency fade
     [TitleGroup("Deck display options"), SerializeField] bool _deckEditMode;
 
-    [ReadOnly] public UnityEvent<ulong> onItemSelected;
+    [ReadOnly] public UnityEvent<ulong> onEditDeck;
+    [ReadOnly] public UnityEvent<ulong> onSelectDeck;
     private bool loadingInProgress = false;
 
     /// <summary>
@@ -58,11 +58,15 @@ public class DeckListLoader : MonoBehaviour
             var deckInstance = Instantiate(_deckPrefab);
             deckInstance.transform.SetParent(_deckList.transform, false);
 
-            // show or hide the pen overlay
+            // show or hide the edit mode
             deckInstance.GetComponent<DeckController>().DisplayDeckEditMode = _deckEditMode;
             deckInstance.GetComponent<DeckController>().onEditButtonClicked.AddListener(
-                delegate { 
-                    onItemSelected?.Invoke(deckId);
+                delegate {
+                    onEditDeck?.Invoke(deckId);
+                });
+            deckInstance.GetComponent<DeckController>().onSelectButtonClicked.AddListener(
+                delegate {
+                    onSelectDeck?.Invoke(deckId);
                 });
 
             // this should set each deck detail in parallel


### PR DESCRIPTION
Summary of changes:
- Implemented matchmaking
  - Enter with deck
  - Exit
  - Start battle once another player enters and has a compatible ranking
  - Show battle scene when the battle event is detected
- Adapted game logic to match the PepemonBattle logic
  - Battles are now consistent between the blockchain and the game client
- Updated some definitions to match the contract's properties (Cards properties more specifically)

Autogenerated files:
Assets/Scripts/Contracts/PepemonMatchmaker/abi/ContractDefinition/PepemonMatchmakerDefinition.cs

Future improvements:
Check if player's deck is in the wait list when accessing the Matchmaker screen, in cases where the game crashed and the player had to restart it, this would give the player the chance to remove the deck from the wait list.
