### PR TITLE
Update contracts addresses

### DIFF
--- a/Assets/Scenes/StartScreen.unity
+++ b/Assets/Scenes/StartScreen.unity
@@ -7728,6 +7728,7 @@ MonoBehaviour:
       pepemonBattleAddress: 0x16018De06b116b044f257Fe58d915e5da048CE14
       pepemonFactoryAddress: 0x5aC1254f6c8cD976e796c951D7fE92eEF0eB70BE
       pepemonCardDeckAddress: 0xa784b4fcFe0cF627aD2Be650d5467597FCFBFf67
+      pepemonGasLimit: 7500000
       pepemonMatchmakerAddresses:
       - 0x0941517e79a5898B46318B2C66634aa5928fC70f
     - chainId: 31337
@@ -7740,6 +7741,7 @@ MonoBehaviour:
       pepemonBattleAddress: 0x3DF3b26eE45f131960383323b2f9988E73967300
       pepemonFactoryAddress: 0x5aC1254f6c8cD976e796c951D7fE92eEF0eB70BE
       pepemonCardDeckAddress: 0xDA116D9Bc40195371B833fA8280dee2b190aCB49
+      pepemonGasLimit: 0
       pepemonMatchmakerAddresses:
       - 0x47E2B6189436D064a291d61a3f0822356823E26D
     - chainId: 4002
@@ -7749,9 +7751,10 @@ MonoBehaviour:
       chainCurrencyDecimals: 18
       rpcUrl: https://rpc.ankr.com/fantom_testnet
       blockExplorerUrl: https://testnet.ftmscan.com/address/
-      pepemonBattleAddress: 0xBe973123CF4ECC840fbA3aE14DACC6aD80Aaa2A9
+      pepemonBattleAddress: 0xA1E3aeE45Aa74349cD9A1eC290A41F218Ff34EaD
       pepemonFactoryAddress: 0x25e8db00C55b9da7C999Fdc0A9d098Cb0b3aAFfc
       pepemonCardDeckAddress: 0x12EaA00470d8160DC43C11c32fD8c30E5fca0C05
+      pepemonGasLimit: 7500000
       pepemonMatchmakerAddresses:
       - 0x3DD5213768d66B4f1f625784aC8588C472F44b88
       - 0x3DD5213768d66B4f1f625784aC8588C472F44b88
@@ -7766,6 +7769,7 @@ MonoBehaviour:
       pepemonBattleAddress: 0x99dC834eB9cE894eE1142B5aCc6eEdD27cA14887
       pepemonFactoryAddress: 0x888c830242caaa352dc506a2c79d38b3e86102ad
       pepemonCardDeckAddress: 0x665688de6296956f3c7264961511412e02b24070
+      pepemonGasLimit: 7500000
       pepemonMatchmakerAddresses:
       - 0x0EA739B3c290E6194d37ba579948794cA0662705
       - 0x0EA739B3c290E6194d37ba579948794cA0662705

--- a/Assets/Scenes/StartScreen.unity
+++ b/Assets/Scenes/StartScreen.unity
@@ -7749,7 +7749,7 @@ MonoBehaviour:
       chainCurrencyDecimals: 18
       rpcUrl: https://rpc.ankr.com/fantom_testnet
       blockExplorerUrl: https://testnet.ftmscan.com/address/
-      pepemonBattleAddress: 0xA1E3aeE45Aa74349cD9A1eC290A41F218Ff34EaD
+      pepemonBattleAddress: 0xBe973123CF4ECC840fbA3aE14DACC6aD80Aaa2A9
       pepemonFactoryAddress: 0x25e8db00C55b9da7C999Fdc0A9d098Cb0b3aAFfc
       pepemonCardDeckAddress: 0x12EaA00470d8160DC43C11c32fD8c30E5fca0C05
       pepemonMatchmakerAddresses:

--- a/Assets/Scenes/StartScreen.unity
+++ b/Assets/Scenes/StartScreen.unity
@@ -7749,13 +7749,13 @@ MonoBehaviour:
       chainCurrencyDecimals: 18
       rpcUrl: https://rpc.ankr.com/fantom_testnet
       blockExplorerUrl: https://testnet.ftmscan.com/address/
-      pepemonBattleAddress: 0xCBfA151dfCA576EA333C04497B5D723ffEEf1559
-      pepemonFactoryAddress: 0x9460DfaAD34Bc55ee564A6851c58DFC390D7d4ac
+      pepemonBattleAddress: 0xA1E3aeE45Aa74349cD9A1eC290A41F218Ff34EaD
+      pepemonFactoryAddress: 0x25e8db00C55b9da7C999Fdc0A9d098Cb0b3aAFfc
       pepemonCardDeckAddress: 0x12EaA00470d8160DC43C11c32fD8c30E5fca0C05
       pepemonMatchmakerAddresses:
-      - 0x6f2D7Ad24d1B17Cc56f8a43dBB9309ea227724A4
-      - 0x6f2D7Ad24d1B17Cc56f8a43dBB9309ea227724A4
-      - 0x6f2D7Ad24d1B17Cc56f8a43dBB9309ea227724A4
+      - 0x3DD5213768d66B4f1f625784aC8588C472F44b88
+      - 0x3DD5213768d66B4f1f625784aC8588C472F44b88
+      - 0x3DD5213768d66B4f1f625784aC8588C472F44b88
     - chainId: 250
       chainName: Fantom Opera
       chainCurrencyName: FTM

--- a/Assets/ScriptableObjects/Pepemons/Cosmony.asset
+++ b/Assets/ScriptableObjects/Pepemons/Cosmony.asset
@@ -23,7 +23,7 @@ MonoBehaviour:
   Weakness: 10
   Resistence: 10
   Rarity: 0
-  HealthPoints: 6
+  HealthPoints: 30
   Speed: 21
   Intelligence: 7
   Attack: 4

--- a/Assets/ScriptableObjects/Pepemons/Druky.asset
+++ b/Assets/ScriptableObjects/Pepemons/Druky.asset
@@ -23,7 +23,7 @@ MonoBehaviour:
   Weakness: 5
   Resistence: 8
   Rarity: 0
-  HealthPoints: 9
+  HealthPoints: 45
   Speed: 14
   Intelligence: 5
   Attack: 5

--- a/Assets/ScriptableObjects/Pepemons/Fafny.asset
+++ b/Assets/ScriptableObjects/Pepemons/Fafny.asset
@@ -23,7 +23,7 @@ MonoBehaviour:
   Weakness: 0
   Resistence: 2
   Rarity: 0
-  HealthPoints: 8
+  HealthPoints: 40
   Speed: 5
   Intelligence: 6
   Attack: 5

--- a/Assets/ScriptableObjects/Pepemons/Kirimu.asset
+++ b/Assets/ScriptableObjects/Pepemons/Kirimu.asset
@@ -23,7 +23,7 @@ MonoBehaviour:
   Weakness: 5
   Resistence: 8
   Rarity: 0
-  HealthPoints: 8
+  HealthPoints: 40
   Speed: 13
   Intelligence: 6
   Attack: 4

--- a/Assets/ScriptableObjects/Pepemons/Mandraky.asset
+++ b/Assets/ScriptableObjects/Pepemons/Mandraky.asset
@@ -23,7 +23,7 @@ MonoBehaviour:
   Weakness: 3
   Resistence: 0
   Rarity: 0
-  HealthPoints: 8
+  HealthPoints: 39
   Speed: 11
   Intelligence: 5
   Attack: 1

--- a/Assets/ScriptableObjects/Pepemons/Sairy.asset
+++ b/Assets/ScriptableObjects/Pepemons/Sairy.asset
@@ -23,7 +23,7 @@ MonoBehaviour:
   Weakness: 7
   Resistence: 1
   Rarity: 0
-  HealthPoints: 7
+  HealthPoints: 35
   Speed: 20
   Intelligence: 5
   Attack: 5

--- a/Assets/ScriptableObjects/Pepemons/Shapu.asset
+++ b/Assets/ScriptableObjects/Pepemons/Shapu.asset
@@ -23,7 +23,7 @@ MonoBehaviour:
   Weakness: 10
   Resistence: 10
   Rarity: 0
-  HealthPoints: 8
+  HealthPoints: 40
   Speed: 5
   Intelligence: 6
   Attack: 25

--- a/Assets/ScriptableObjects/Pepemons/Unifairy.asset
+++ b/Assets/ScriptableObjects/Pepemons/Unifairy.asset
@@ -23,7 +23,7 @@ MonoBehaviour:
   Weakness: 1
   Resistence: 6
   Rarity: 0
-  HealthPoints: 6
+  HealthPoints: 32
   Speed: 18
   Intelligence: 5
   Attack: 5

--- a/Assets/ScriptableObjects/Pepemons/Venumu.asset
+++ b/Assets/ScriptableObjects/Pepemons/Venumu.asset
@@ -23,7 +23,7 @@ MonoBehaviour:
   Weakness: 7
   Resistence: 5
   Rarity: 0
-  HealthPoints: 8
+  HealthPoints: 40
   Speed: 5
   Intelligence: 5
   Attack: 5

--- a/Assets/ScriptableObjects/Pepemons/Witchenry.asset
+++ b/Assets/ScriptableObjects/Pepemons/Witchenry.asset
@@ -23,7 +23,7 @@ MonoBehaviour:
   Weakness: 6
   Resistence: 7
   Rarity: 0
-  HealthPoints: 6
+  HealthPoints: 29
   Speed: 14
   Intelligence: 7
   Attack: 11

--- a/Assets/Scripts/Contracts/PepemonMatchmaker.cs
+++ b/Assets/Scripts/Contracts/PepemonMatchmaker.cs
@@ -20,7 +20,7 @@ public class PepemonMatchmaker
     /// PepemonMatchmaker address
     /// </summary>
     private static string[] Addresses => Web3Controller.instance.GetChainConfig().pepemonMatchmakerAddresses;
-
+    private static long BattleGasLimit => Web3Controller.instance.GetChainConfig().pepemonGasLimit;
 
     public static async Task<string> GetDeckOwner(PepemonLeagues league, ulong deckId)
     {
@@ -100,6 +100,7 @@ public class PepemonMatchmaker
             new EnterFunction()
             {
                 DeckId = deckId,
+                Gas = BattleGasLimit > 0 ? BattleGasLimit : null
             },
             Addresses[(int)league]);
     }

--- a/Assets/Scripts/Controllers/GameController.cs
+++ b/Assets/Scripts/Controllers/GameController.cs
@@ -261,6 +261,8 @@ public class GameController : MonoBehaviour
 
                     if (_player1.CurrentHP <= 0) BattleResut(_player2);
                 }
+                Debug.Log("goForBattle _player1.CurrentHP=" + _player1.CurrentHP);
+                Debug.Log("goForBattle _player2.CurrentHP=" + _player2.CurrentHP);
 
                 Debug.Log("waiting 2f");
                 yield return new WaitForSeconds(1f);

--- a/Assets/Scripts/Controllers/GameController.cs
+++ b/Assets/Scripts/Controllers/GameController.cs
@@ -132,12 +132,9 @@ public class GameController : MonoBehaviour
     void InitFirstRound()
     {
         _roundNumber = 0;
-        _player1.Initialise(1);
-        _player2.Initialise(2);
+        _player1.Initialize();
+        _player2.Initialize();
         _uiController.InitialiseGame(_player1, _player2);
-
-        _player1.GetAndShuffelDeck(PLAYER1_SEED, _roundNumber, battleSeed);
-        _player2.GetAndShuffelDeck(PLAYER2_SEED, _roundNumber, battleSeed);
     }
 
     IEnumerator LoopGame()
@@ -177,13 +174,13 @@ public class GameController : MonoBehaviour
             //Need to refresh decks
 
             // Shuffle player1 support cards
-            _player1.GetAndShuffelDeck(PLAYER1_SEED, _roundNumber, battleSeed);
+            _player1.ShuffelCurrentDeck(PLAYER1_SEED, _roundNumber, battleSeed);
 
             //Reset played card count
             _player1.PlayedCardCount = 0;
 
             // Shuffle player2 support cards
-            _player2.GetAndShuffelDeck(PLAYER2_SEED, _roundNumber, battleSeed);
+            _player2.ShuffelCurrentDeck(PLAYER2_SEED, _roundNumber, battleSeed);
 
             //Reset played card count
             _player2.PlayedCardCount = 0;
@@ -264,8 +261,6 @@ public class GameController : MonoBehaviour
 
                     if (_player1.CurrentHP <= 0) BattleResut(_player2);
                 }
-                Debug.Log("goForBattle _player1.CurrentHP=" + _player1.CurrentHP);
-                Debug.Log("goForBattle _player2.CurrentHP=" + _player2.CurrentHP);
 
                 Debug.Log("waiting 2f");
                 yield return new WaitForSeconds(1f);

--- a/Assets/Scripts/Controllers/Web3Settings.cs
+++ b/Assets/Scripts/Controllers/Web3Settings.cs
@@ -22,6 +22,7 @@ public class Web3Settings
         public string pepemonBattleAddress;
         public string pepemonFactoryAddress;
         public string pepemonCardDeckAddress;
+        public long pepemonGasLimit;
         public string[] pepemonMatchmakerAddresses;
     }
 

--- a/Assets/Scripts/Data/Player.cs
+++ b/Assets/Scripts/Data/Player.cs
@@ -18,15 +18,15 @@ namespace Pepemon.Battle
         [BoxGroup("Runtime")] public int CurrentHP;
         [BoxGroup("Runtime")] public Deck CurrentDeck;
         [BoxGroup("Runtime")] public Hand CurrentHand;
-        [BoxGroup("Runtime")] public int StartingIndex;
         [BoxGroup("Runtime")] public int PlayedCardCount;
         [BoxGroup("Runtime")] public CurrentBattleCardStats CurrentPepemonStats = new(); // all stats of the player's battle cards currently
 
 
-        public void Initialise(int index)
+        public void Initialize()
         {
             CurrentHP = PlayerPepemon.HealthPoints;
-            StartingIndex = index;
+            CurrentDeck.ClearDeck();
+            CurrentDeck.GetDeck().AddRange(PlayerDeck.GetDeck());
         }
 
         public void SetPlayerDeck(BattleCard pepemon, IEnumerable<Card> supportCards)
@@ -36,12 +36,8 @@ namespace Pepemon.Battle
             PlayerDeck.GetDeck().AddRange(supportCards);
         }
 
-        public void GetAndShuffelDeck(BigInteger seed, BigInteger currentTurn, BigInteger battleRng)
+        public void ShuffelCurrentDeck(BigInteger seed, BigInteger currentTurn, BigInteger battleRng)
         {
-            // Get local copy of deck and shuffle
-            CurrentDeck.ClearDeck();
-            CurrentDeck.GetDeck().AddRange(PlayerDeck.GetDeck());
-
             // calculate random seed like in solidity
             var abiEncode = new ABIEncode();
             CurrentDeck.ShuffelDeck(


### PR DESCRIPTION
Use contracts addresses from https://github.com/pepemon-dao/battle-contracts/pull/26

~~Still in draft because some battles are failing, so maybe the battle contract will be updated to use https://github.com/pepemon-dao/battle-contracts/pull/25~~ already updated

Update cards statuses to match the ones deployed on pepemonFactory on fantom testnet

Update code to match new pepemonBattle contract code